### PR TITLE
memswap const removal and asm contraint

### DIFF
--- a/include/sh4zam/shz_mem.h
+++ b/include/sh4zam/shz_mem.h
@@ -360,8 +360,8 @@ SHZ_INLINE void* shz_memcpy32(void* SHZ_RESTRICT dst,
 }
 
 SHZ_INLINE void shz_memswap32_1(void *SHZ_RESTRICT p1, void *SHZ_RESTRICT p2) {
-    const shz_alias_uint32_t (*a)[8] = (const shz_alias_uint32_t (*)[8])p1;
-          shz_alias_uint32_t (*b)[8] = (      shz_alias_uint32_t (*)[8])p2;
+    shz_alias_uint32_t (*a)[8] = (shz_alias_uint32_t (*)[8])p1;
+    shz_alias_uint32_t (*b)[8] = (shz_alias_uint32_t (*)[8])p2;
 
     SHZ_PREFETCH(b);
     SHZ_FSCHG(true);
@@ -387,7 +387,7 @@ SHZ_INLINE void shz_memswap32_1(void *SHZ_RESTRICT p1, void *SHZ_RESTRICT p2) {
         fmov.d  xd2, @-%[b]
         fmov.d  xd0, @-%[b]
     )"
-    : [a] "+r" (a), [b] "+r" (b), "=&m" (*a), "=&m" (*b));
+    : [a] "+r" (a), [b] "+r" (b), "=m" (*a), "=m" (*b));
 
     SHZ_FSCHG(false);
 }

--- a/include/sh4zam/shz_mem.h
+++ b/include/sh4zam/shz_mem.h
@@ -387,7 +387,7 @@ SHZ_INLINE void shz_memswap32_1(void *SHZ_RESTRICT p1, void *SHZ_RESTRICT p2) {
         fmov.d  xd2, @-%[b]
         fmov.d  xd0, @-%[b]
     )"
-    : [a] "+r" (a), [b] "+r" (b), "=m" (*a), "=m" (*b));
+    : [a] "+r" (a), [b] "+r" (b), "+m" (*a), "+m" (*b));
 
     SHZ_FSCHG(false);
 }


### PR DESCRIPTION
Additional fix to try appease the C++ compiler. Remove const from p1 in memswap32_1.

Also an attempt at fixing this error:
`error: ‘&’ constraint used with no register class`
Does not appear to accept early-clobber on memory.

I was not too sure so I haven't changed it here, but should the constraint here be `+m` instead of `=m`?