### PR TITLE
Axis angle and Quat matrix fixes

### DIFF
--- a/include/sh4zam/shz_matrix.h
+++ b/include/sh4zam/shz_matrix.h
@@ -414,17 +414,17 @@ SHZ_INLINE shz_quat_t shz_mat4x4_to_quat(const shz_mat4x4_t* mat) SHZ_NOEXCEPT {
 }
 
 SHZ_INLINE void shz_mat4x4_set_rotation_quat(shz_mat4x4_t* m, shz_quat_t q) SHZ_NOEXCEPT {
-	m->elem2D[0][0] = 2.0f * (q.w * q.w + q.x * q.x) - 1.0f;
+	m->elem2D[0][0] = 1.0f - 2.0f * (q.y * q.y + q.z * q.z);
 	m->elem2D[1][0] = 2.0f * (q.x * q.y - q.w * q.z);
-	m->elem2D[2][0] = 2.0f * (q.x * q.z + q.x * q.y);
+	m->elem2D[2][0] = 2.0f * (q.x * q.z + q.y * q.w);
 
 	m->elem2D[0][1] = 2.0f * (q.x * q.y + q.w * q.z);
-	m->elem2D[1][1] = 2.0f * (q.w * q.w + q.y * q.w) - 1.0f;
-	m->elem2D[2][1] = 2.0f * (q.y * q.z - q.x * q.y);
+	m->elem2D[1][1] = 1.0f - 2.0f * (q.x * q.x + q.z * q.z);
+	m->elem2D[2][1] = 2.0f * (q.y * q.z - q.x * q.w);
 
-	m->elem2D[0][2] = 2.0f * (q.y * q.z - q.w * q.y);
+	m->elem2D[0][2] = 2.0f * (q.x * q.z - q.w * q.y);
 	m->elem2D[1][2] = 2.0f * (q.y * q.z + q.w * q.x);
-	m->elem2D[2][2] = 2.0f * (q.w * q.w + q.z * q.z) - 1.0f;
+	m->elem2D[2][2] = 1.0f - 2.0f * (q.x * q.x + q.y * q.y);
 }
 
 SHZ_INLINE void shz_mat4x4_init_rotation_quat(shz_mat4x4_t* m, shz_quat_t q) SHZ_NOEXCEPT {

--- a/include/sh4zam/shz_quat.h
+++ b/include/sh4zam/shz_quat.h
@@ -63,14 +63,13 @@ SHZ_INLINE shz_quat_t shz_quat_from_angles_xyz(float xangle, float yangle, float
     );
 }
 
-// Should this be normalizing?
 SHZ_INLINE shz_quat_t shz_quat_from_axis_angle(shz_vec3_t axis, float angle) SHZ_NOEXCEPT {
     shz_sincos_t half_alpha = shz_sincosf(angle * 0.5f);
 
     return shz_quat_init(half_alpha.cos,
-                         half_alpha.sin * shz_cosf(axis.x),
-                         half_alpha.sin * shz_cosf(axis.y),
-                         half_alpha.sin * shz_cosf(axis.z));
+                         half_alpha.sin * axis.x,
+                         half_alpha.sin * axis.y,
+                         half_alpha.sin * axis.z);
 }
 
 shz_quat_t shz_quat_from_look_axis(shz_vec3_t forward, shz_vec3_t up) SHZ_NOEXCEPT;


### PR DESCRIPTION
Removes cosf from the axis in `shz_quat_from_axis_angle`. Was a comment above about normalizing. Would just let the user do that if they for some reason use a non-unit axis.

Updated matrix from quat, nothing was wrong with the position of `- 1.0f`. I just moved it whilst ordering thing but they're equivalent.

Just an issue on the diagonal in (1,1) and (2,2). 'w' should never be in the diagonals.