### PR TITLE
Add distance_sqr and modify signature for template parameter deduction

### DIFF
--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -126,8 +126,12 @@ struct vecN: C {
         *this = shz_vec_normalize_safe(*this);
     }
 
-    SHZ_FORCE_INLINE float distance(CppType other) const noexcept {
-        return shz_vec_distance(*this, other);
+    SHZ_FORCE_INLINE float distance(this const CppType& self, const CppType& other) noexcept {
+        return shz_vec_distance(self, other);
+    }
+
+    SHZ_FORCE_INLINE float distance_sqr(this const CppType& self, const CppType& other) noexcept {
+        return shz_vec_distance_sqr(self, other);
     }
 
     SHZ_FORCE_INLINE CppType reflect(CppType normal) const noexcept {


### PR DESCRIPTION
Adds the squared variant of distance to the C++ API.

Also was having some troubles with template deduction, resolved by using the same method that `dot` appears to use.