### PR TITLE
README: Fix Doxygen syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NOTE: <i>Where applicable, the C API also includes a variety of type-generic rou
 ## C++23
 For C++ code, include the header files with the `.hpp` extensions or `sh4zam/shz_sh4zam.hpp` to include everything.
 
-```c++
+```cxx
 #include <sh4zam/shz_sh4zam.hpp>
 
 int main(int argc, const char* argv[]) {


### PR DESCRIPTION
I just noticed this was missing from the previous PR.

It's required for the syntax highlighting to work on Doxygen.
It doesn't affect GitHub's rendering.