### PR TITLE
Add test case for barycentric_lerpf

### DIFF
--- a/test/shz_scalar_test_suite.cpp
+++ b/test/shz_scalar_test_suite.cpp
@@ -73,7 +73,13 @@ GBL_TEST_CASE(lerpf)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(barycentric_lerpf)
-
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(0.0f, 1.0f, 2.0f, 0.5f, 0.0f) == 0.5f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(0.0f, 1.0f, 2.0f, 0.0f, 0.5f) == 1.0f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(0.0f, 1.0f, 2.0f, 0.5f, 0.5f) == 2.0f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(3.0f, 4.0f, 5.0f, 0.0f, 0.0f) == 3.0f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(3.0f, 4.0f, 5.0f, 1.0f, 0.0f) == 4.0f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(3.0f, 4.0f, 5.0f, 0.0f, 1.0f) == 5.0f);
+    GBL_TEST_VERIFY(shz::barycentric_lerpf(1.0f, 2.0f, 3.0f, 1.0f, 1.0f) == 4.0f);
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(inv_sqrtf)


### PR DESCRIPTION
This test case will check the following conditions:

- Interpolate between a=0, b=1, c=2 with u=0.5, v=0.0 → moves halfway from a toward b

- Interpolate with u=0.0, v=0.5 → moves halfway from a toward c

- Interpolate with u=0.5, v=0.5 → blends influence from both b and c starting at a

- Interpolate with u=0.0, v=0.0 → returns the starting value a

- Interpolate with u=1.0, v=0.0 → fully influenced by b

- Interpolate with u=0.0, v=1.0 → fully influenced by c

- Interpolate with u=1.0, v=1.0 → goes beyond both b and c starting from a