### PR TITLE
renaming shz_matrix3x3_trans_vec3 

### DIFF
--- a/include/sh4zam/shz_matrix.h
+++ b/include/sh4zam/shz_matrix.h
@@ -376,7 +376,7 @@ typedef struct shz_mat3x4 {
     };
 } shz_mat3x4_t;
 
-SHZ_INLINE shz_vec3_t shz_matrix3x3_trans_vec3(const shz_mat3x3_t* m, shz_vec3_t v) SHZ_NOEXCEPT;
+SHZ_INLINE shz_vec3_t shz_mat3x3_trans_vec3(const shz_mat3x3_t* m, shz_vec3_t v) SHZ_NOEXCEPT;
 
 //! \endcond
 

--- a/include/sh4zam/shz_matrix.inl.h
+++ b/include/sh4zam/shz_matrix.inl.h
@@ -435,7 +435,7 @@ SHZ_INLINE void shz_mat4x4_transpose(const shz_mat4x4_t* mat, shz_mat4x4_t* out)
     shz_xmtrx_store_4x4(out);
 }
 
-SHZ_INLINE shz_vec3_t shz_matrix3x3_trans_vec3(const shz_mat3x3_t* m, shz_vec3_t v) SHZ_NOEXCEPT {
+SHZ_INLINE shz_vec3_t shz_mat3x3_trans_vec3(const shz_mat3x3_t* m, shz_vec3_t v) SHZ_NOEXCEPT {
     shz_vec3_t out;
 
     register float fr0 asm("fr0") = v.x;


### PR DESCRIPTION
... to shz_mat3x3_trans_vec3 for concistency in naming with methods like shz_matrix4x4_trans_vec4