### PR TITLE
Lang Version, Architectures, and Utilities precursor update.

### DIFF
--- a/include/sh4zam/shz_cdefs.h
+++ b/include/sh4zam/shz_cdefs.h
@@ -13,8 +13,219 @@
 #ifndef SHZ_CDEFS_H
 #define SHZ_CDEFS_H
 
+#ifndef __cplusplus
 #include <stdint.h>
 #include <assert.h>
+#else
+#include <cstdint>
+#include <cassert>
+#endif// C else C++
+
+//================================================================
+
+#ifdef __has_include
+#define SHZ_HAS_INCLUDE(x)        __has_include(x)
+#else
+#define SHZ_HAS_INCLUDE(x)        0
+#endif//__has_include
+
+//================================================================
+
+#if defined(_MSC_VER)
+// <intrin.h> includes { immintrin.h | mm3dnow.h | armintr.h | arm_neon.h | arm64intr.h | arm64_neon.h }
+// depening on supported target architecture
+// Also includes { vcruntime.h | setjmp.h | **softintrin.h** }
+// (**) only #ifndef {defined(_M_CEE_PURE)} and #if (defined(_M_ARM64EC) && !defined(_DISABLE_SOFTINTRIN_))
+#include <intrin.h>
+//----------------------------------------------------------------
+//TODO: Maybe keep this, though I didn't find the declarations/definitions for
+//      __check_arch_support nor __check_isa_support, aside from documentation on them existing.
+//      They're supposedly inside <immintrin.h>, but their declaration/definition was not located
+//      in my recursive search in all included headers.
+//----------------------------------------------------------------
+// #if defined(_INCLUDED_IMM)
+// #include <isa_availability.h>
+// // `isa_feature`    Bit flags for checking availability of (enum ISA_AVAILABILITY) 
+// // `avx10_version`  Only for AVX10.x, 0 when AVX10 version check isn't required.
+// #define SHZ_MSVC_CHECK_ISA_SUPPORT(isa_feature,   avx10_version)  ( \
+//         __check_arch_support((isa_feature), (avx10_version)) || \
+//         __check_isa_support ((isa_feature), (avx10_version))    \
+//     )
+//
+// // __check_arch_support - detects if the arch flag supports the specified ISA feature and AVX10 version at compile time.
+// // __check_isa_support  - detects if the processor supports the specified ISA feature and AVX10 version at run time.
+// #else
+// #define SHZ_MSVC_CHECK_ISA_SUPPORT(isa_feature, avx10_version)  0
+// #endif
+// #else
+// #define SHZ_MSVC_CHECK_ISA_SUPPORT(isa_feature, avx10_version)  0
+#endif// MSVC Headers
+
+//================================================================
+
+#define SHZ_C_23        202311L // C23
+#define SHZ_C_17        201710L // C17
+#define SHZ_C_11        201112L // C11
+#define SHZ_C_99        199901L // C99
+#define SHZ_C_95        199409L // C95
+#define SHZ_C_89        198999L // C89 (fill-in version, __STDC_VERSION__ was undefined before C95)
+
+//================================================================
+
+#define SHZ_CXX_26      202401L // C++26, NOTE: Current Experimental Version, update when standardized.
+#define SHZ_CXX_23      202302L // C++23
+#define SHZ_CXX_20      202002L // C++20
+#define SHZ_CXX_17      201703L // C++17
+#define SHZ_CXX_14      201402L // C++14
+#define SHZ_CXX_11      201103L // C++11
+#define SHZ_CXX_98      199711L // C++98
+
+//================================================================
+// C Version
+//================================================================
+#ifdef  __STDC_VERSION__
+//----------------------------------------------------------------
+#   if defined(_MSC_VER) && !defined(__cplusplus)
+//TODO: Going to need to add feature testing for acquiring the C version
+//      without relying on an external macro definition/configuration.
+#   define shz_c_version    SHZ_C_11
+#   else
+#   define shz_c_version    __STDC_VERSION__
+#   endif//shz_c_version (temporary)
+//----------------------------------------------------------------
+#   if   (shz_c_version >=  SHZ_C_23)
+    // C23
+#   define SHZ_C_VERSION    SHZ_C_23
+#   elif (shz_c_version >=  SHZ_C_17)
+    // C17
+#   define SHZ_C_VERSION    SHZ_C_17
+#   elif (shz_c_version >=  SHZ_C_11)
+    // C11
+#   define SHZ_C_VERSION    SHZ_C_11
+#   elif (shz_c_version >=  SHZ_C_99)
+    // C99
+#   define SHZ_C_VERSION    SHZ_C_99
+#   elif (shz_c_version >=  SHZ_C_95)
+    // C95
+#   define SHZ_C_VERSION    SHZ_C_95
+#   endif//SHZ_C_VERSION
+//----------------------------------------------------------------
+#   undef shz_c_version
+//----------------------------------------------------------------
+#elif !defined(__cplusplus)
+    // C89
+#   define SHZ_C_VERSION    SHZ_C_89 
+#endif//__STDC_VERSION__
+
+//================================================================
+// C++ Version
+//================================================================
+#ifdef __cplusplus
+//----------------------------------------------------------------
+#   if defined(_MSVC_LANG) && _MSVC_LANG > __cplusplus
+#   define shz_cxx_version  _MSVC_LANG
+#   else
+#   define shz_cxx_version  __cplusplus
+#   endif//shz_cxx_version (temporary)
+//----------------------------------------------------------------
+#   if   shz_cxx_version >= SHZ_CXX_26
+    // C++26 (experimental)
+#   define SHZ_CXX_VERSION  SHZ_CXX_26
+#   elif shz_cxx_version >= SHZ_CXX_23
+    // C++23
+#   define SHZ_CXX_VERSION  SHZ_CXX_23
+#   elif shz_cxx_version >= SHZ_CXX_20
+    // C++20
+#   define SHZ_CXX_VERSION  SHZ_CXX_20
+#   elif shz_cxx_version >= SHZ_CXX_17
+    // C++17
+#   define SHZ_CXX_VERSION  SHZ_CXX_17
+#   elif shz_cxx_version >= SHZ_CXX_14
+    // C++14
+#   define SHZ_CXX_VERSION  SHZ_CXX_14
+#   elif shz_cxx_version >= SHZ_CXX_11
+    // C++11
+#   define SHZ_CXX_VERSION  SHZ_CXX_11
+#   elif shz_cxx_version >= SHZ_CXX_98
+    // C++98
+#   define SHZ_CXX_VERSION  SHZ_CXX_98
+#   endif//SHZ_CXX_VERSION
+//----------------------------------------------------------------
+#   undef  shz_cxx_version
+//----------------------------------------------------------------
+#endif//__cplusplus
+
+//================================================================
+// Architectures { 0 = NOT_TARGET, 32/64/NNN = IS_TARGET Architecture}
+//================================================================
+
+#if defined(__DREAMCAST__) || defined(__SH4__)
+// 32-bit SH4 architecture
+#define SHZ_ARCH_SH4            32
+#endif//SH4/SuperH 4
+
+#if defined(_M_IX86) || defined(__i386__)
+// 32-bit x86 architecture
+#define SHZ_ARCH_X86            32
+#endif//x86
+
+#if defined(_M_X64) || defined(__x86_64__)
+// 64-bit x86_64 architecture
+#define SHZ_ARCH_X64            64
+#endif//x86_64/amd64
+
+#if defined(_M_ARM) || defined(__arm__)
+// 32-bit ARM architecture
+#define SHZ_ARCH_ARM            32
+#endif//arm (armv7-a)
+
+#if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__)
+// 64-bit ARM64 architecture
+#define SHZ_ARCH_ARM64          64
+#endif//arm64/aarch64
+
+#if defined(__riscv__) && (defined(__riscv_lp64) || defined(__riscv_lp64d))
+// 64-bit RISC-V 64 (RV64) architecture
+#define SHZ_ARCH_RISCV64        64
+#endif//riscv64/rv64
+
+//TODO: Add in MIPS target architectures
+
+//----------------------------------------------------------------
+// #ifndef, then it is NOT the TARGET Architecture
+//----------------------------------------------------------------
+
+#ifndef SHZ_ARCH_SH4
+#define SHZ_ARCH_SH4            0
+#endif//SHZ_ARCH_SH4
+
+#ifndef SHZ_ARCH_X86
+#define SHZ_ARCH_X86            0
+#endif//SHZ_ARCH_X86
+
+#ifndef SHZ_ARCH_X64
+#define SHZ_ARCH_X64            0
+#endif//SHZ_ARCH_X64
+
+#ifndef SHZ_ARCH_ARM
+#define SHZ_ARCH_ARM            0
+#endif//SHZ_ARCH_ARM
+
+#ifndef SHZ_ARCH_ARM64
+#define SHZ_ARCH_ARM64          0
+#endif//SHZ_ARCH_ARM64
+
+#ifndef SHZ_ARCH_RISCV64
+#define SHZ_ARCH_RISCV64        0
+#endif//SHZ_ARCH_RISCV64
+
+#ifndef SHZ_ARCH_MIPS
+#define SHZ_ARCH_MIPS           0
+#endif//SHZ_ARCH_MIPS
+
+//================================================================
+// Utilities
+//================================================================
 
 /*! \name   Utilities
  *  \brief  Miscellaneous function-like macros
@@ -41,6 +252,88 @@
  *  \brief Defines for commonly-used GCC attributes.
  *  @{
  */
+#if defined(_MSC_VER)
+
+//! Forces a function or type to be aligned by \p N bytes.
+#define SHZ_ALIGNAS(N)              __declspec(align(N))
+
+//! (UNSUPPORTED) Tells MSVC that a scalar type is to be treated as a vector of size \p N.
+#define SHZ_SIMD(N)                 //NOTE: No MSVC equivalent available.
+
+//! (UNSUPPORTED) Tells MSVC that a particular function should be optimized for performance.
+#define SHZ_HOT                     //NOTE: No MSVC equivalent, only MSVC equivalent is a pragma region.
+
+//! Aligns a function by the size of an icache line (32 bytes).
+#define SHZ_ICACHE_ALIGNED          __declspec(align(32))
+
+//! Forces MSVC to inline the given function.
+#define SHZ_FORCE_INLINE            __forceinline SHZ_INLINE
+
+//! Prevents MSVC from inlining the given function.
+#define SHZ_NO_INLINE               __declspec(noinline)
+
+//! (UNSUPPORTED) Forces MSVC to inline all calls to other functions made within the tagged function.
+#define SHZ_FLATTEN                 //NOTE: No MSVC equivalent available.
+
+//! Tells MSVC not to introduce any extra padding for the given type.
+#define SHZ_PACKED                  __pragma(pack(1))
+
+//! Tells MSVC the function has no effects other than returning a value that depends on its arguments and global variables.
+#define SHZ_PURE                    __declspec(noalias)
+
+//! (UNSUPPORTED) Tells MSVC that the decorated pointer may be breaking strict aliasing rules for C and C++
+#define SHZ_ALIASING                //NOTE: No MSVC equivalent available.
+
+#if SHZ_CXX_VERSION >= SHZ_CXX_20
+//! Tells MSVC that the expression is likely to be true (used for conditional and loop optimizations)
+#define SHZ_LIKELY(e)               (e) [[likely]]
+
+//! Tells MSVC that the expression is likely to be false (used for conditional and loop optimizations)
+#define SHZ_UNLIKELY(e)             (e) [[unlikely]]
+#else
+//! (UNSUPPORTED) Tells MSVC that the expression is likely to be true (used for conditional and loop optimizations)
+#define SHZ_LIKELY(e)               (e)
+
+//! (UNSUPPORTED) Tells MSVC that the expression is likely to be false (used for conditional and loop optimizations)
+#define SHZ_UNLIKELY(e)             (e)
+#endif// >=C++20 else (UNSUPPORTED)
+
+#if SHZ_ARCH_ARM || SHZ_ARCH_ARM64
+//! Tells MSVC to use its builtin intrinsic for prefetching (better instruction scheduling than pure ASM pref)
+#define SHZ_PREFETCH(a)             __prefetch(a, _MM_HINT_T0)
+
+//! Tells MSVC to issue a prefetch, using _ReadWriteBarrier() so that it cannot be reordered
+#define SHZ_PREFETCH_VOLATILE(a)    do { \
+                                        _ReadWriteBarrier(); \
+                                        __prefetch(a, _MM_HINT_T0); \
+                                        _ReadWriteBarrier(); \
+                                    } while(0)
+#else
+//! Tells MSVC to use its builtin intrinsic for prefetching (better instruction scheduling than pure ASM pref)
+#define SHZ_PREFETCH(a)             _mm_prefetch(a, _MM_HINT_T0)
+
+//! Tells MSVC to issue a prefetch, using _ReadWriteBarrier() so that it cannot be reordered
+#define SHZ_PREFETCH_VOLATILE(a)    do { \
+                                        _ReadWriteBarrier(); \
+                                        _mm_prefetch(a, _MM_HINT_T0); \
+                                        _ReadWriteBarrier(); \
+                                    } while(0)
+#endif// arm/arm64 else x86/x64
+
+//! Put this before a function definition to tell MSVC to use fast math optimizations on a specific function.
+#define SHZ_FAST_MATH               __pragma(fp_contract(on)) \
+                                    __pragma(fenv_access(off)) \
+                                    __pragma(float_control(except, off)) \
+                                    __pragma(float_control(precise, off))
+
+//! Put this before a function definition to tell MSVC to NOT use fast math optimizations on a specific function.
+#define SHZ_NO_FAST_MATH            __pragma(fp_contract(off)) \
+                                    __pragma(fenv_access(on)) \
+                                    __pragma(float_control(except, on)) \
+                                    __pragma(float_control(precise, on))
+
+//----------------------------------------------------------------
+#else
 //! Forces a function or type to be aligned by \p N bytes.
 #define SHZ_ALIGNAS(N)           __attribute__((aligned((N))))
 //! Tells GCC that a scalar type is to be treated as a vector of size \p N.
@@ -73,6 +366,7 @@
 #define SHZ_FAST_MATH           __attribute__((optimize("fast-math")))
 //! Put this before a function definition to tell GCC to NOT use fast math optimizations on a specific function.
 #define SHZ_NO_FAST_MATH        __attribute__((optimize("no-fast-math")))
+#endif//MSVC else (GCC/CLANG)
 
 #ifndef __cplusplus
     //! Dummy define provided for C++ compatibility
@@ -94,13 +388,22 @@
 #   define SHZ_DECLS_END        }
     //! Requests a function or member to be inlined (nonforcibly).
 #   define SHZ_INLINE           inline
+
+#if defined(_MSC_VER)
+    //! Tells MSVC the function has no effects other than returning a value that depends only on its arguments.
+#   define SHZ_CONST            SHZ_PURE SHZ_FORCE_INLINE constexpr
+    //! (SUPPORTED IN MSVC), define provided for C compatibility and macro non-/aliasing.
+#   define SHZ_RESTRICT         __restrict
+#else
     //! Tells GCC the function has no effects other than returning a value that depends only on its arguments.
 #   define SHZ_CONST            __attribute__((const)) constexpr
     //! Dummy define provided for C compatibility
 #   define SHZ_RESTRICT
+#endif
+
     //! Tells the compiler that the function does not throw exceptions
 #   define SHZ_NOEXCEPT         noexcept
-#endif
+#endif//C else C++
 //! @}
 //! \endcond
 
@@ -144,7 +447,11 @@ typedef struct shz_mat4x4 shz_mat4x4_t;
 /*! \endcond */
 
 //! \cond
-#define SHZ_STRINGIFY_(a)       #a
+#define SHZ_STRINGIFY_(a)       #a  // surround with double quotes (")
+//! \endcond
+
+//! \cond
+#define SHZ_CHARIFY_(a)         #@a // surround with single quotes (')
 //! \endcond
 
 #endif // SHZ_CDEFS_H


### PR DESCRIPTION
1. Added C/C++ versions for preprocessor handling that's a prerequisite to the next round of updates which will be adding support for features only available starting from C++20/23 into C++17 (maybe C++11, though we'll see, C++17 is good enough for now).

2. Added Architectures for preprocessor handling that's also a prerequisite for the next round of updates.

3. Added in as many (and I mean as many as I could after hours of reading documentation and cross referencing both MSVC/GCC compilers), macros under Utilities in `include/sh4zam/shz_cdefs.h`.

4. There are some commented sections and //NOTE:s //TODO:s inside there that I wanted to include just because it's a maybe, maybe not useful, no harm while it's commented out, but something to discuss in more detail later `SHZ_MSVC_CHECK_ISA_SUPPORT(isa_feature, avx10_version)`.

5. Included a `SHZ_HAS_INCLUDE` macro around `__has_include` as a convenience macro.

6. Added a preprocessor condition around the headers for the C/C++ version of them, which admittedly, includes the C headers anyway, but they include some useful macro definitions, utilities, and ::std:: namespace anyways. a. These headers are `<cstdint>` and `<cassert>` for the C++ version, then `<stdint.h>` and `<assert.h>` for the C version.

The goal for the next update is to utilize the precursor (this update) before moving into the `.hpp` files and adding in the C++17/20 versions around where we have >=C++23 features (Explicit Object Parameter, aka Deducing `this`), For Reference:  https://cppreference.com/w/cpp/language/function.html#Explicit_object_parameter