### PR TITLE
Added C23 methods for inverting 3x3 and 4x4 matrixes

### DIFF
--- a/include/sh4zam/shz_matrix.h
+++ b/include/sh4zam/shz_matrix.h
@@ -324,6 +324,61 @@ SHZ_INLINE float shz_mat4x4_determinant(const shz_mat4x4_t* mat) SHZ_NOEXCEPT;
 */
 SHZ_INLINE void shz_mat4x4_transpose(const shz_mat4x4_t* mat, shz_mat4x4_t* out) SHZ_NOEXCEPT;
 
+
+/*!
+    Stores the transpose of 3x3 matrix \p mat within \p out.
+    
+    mtrx: Pointer to the 3x3 matrix to transpose.
+    out: Pointer to the resulting transposed matrix.
+
+    \warning This routine clobbers XMTRX.
+
+ */
+SHZ_INLINE void shz_mat3x3_transpose(const shz_mat3x3_t* mat, shz_mat3x3_t* out) SHZ_NOEXCEPT;
+
+/*!
+    Computes the inverse of a 3x3 matrix, saves cycles by not scaling by the
+    determinant, which makes sense when used for normals and lighting that are
+    usually normalized later.
+    
+    mtrx: Pointer to the 3x3 matrix to invert.
+    out: Pointer to the resulting inverted matrix.
+    
+    \note
+    Only valid if the matrix is known to be orthonormal.
+
+    \warning This routine clobbers XMTRX.
+ */
+SHZ_INLINE void shz_mat3x3_inverse_unscaled(const shz_mat3x3_t* mtrx, shz_mat3x3_t* out) SHZ_NOEXCEPT;
+
+/*!
+    Computes the inverse of a 3x3 matrix.
+    
+    mtrx: Pointer to the 3x3 matrix to invert.
+    out: Pointer to the resulting inverted matrix.
+    
+    \note
+    Only valid for non-singular matrices.
+
+    \warning This routine clobbers XMTRX.
+ */
+SHZ_INLINE void shz_mat3x3_inverse(const shz_mat3x3_t* mtrx, shz_mat3x3_t* out) SHZ_NOEXCEPT;
+
+
+/*!
+    Computes the inverse of a 4x4 matrix.
+    
+    mtrx: Pointer to the 4x4 matrix to invert.
+    out: Pointer to the resulting inverted matrix.
+    
+    \note
+    In-place inversion (mtrx == out) is not supported.
+
+    \warning This routine clobbers XMTRX.
+*/
+static void shz_mat4x4_inverse(const shz_mat4x4_t* mtrx, shz_mat4x4_t* out) SHZ_NOEXCEPT;
+
+
 //! @}
 
 //! \cond UNDOCUMENTED

--- a/include/sh4zam/shz_matrix.inl.h
+++ b/include/sh4zam/shz_matrix.inl.h
@@ -489,4 +489,151 @@ SHZ_INLINE shz_vec3_t shz_mat3x3_trans_vec3(const shz_mat3x3_t* m, shz_vec3_t v)
     return out;
 }
 
+SHZ_INLINE void shz_mat3x3_transpose(const shz_mat3x3_t* mtrx,
+                          shz_mat3x3_t* out) SHZ_NOEXCEPT {
+    shz_xmtrx_load_transpose_3x3((const float*)mtrx);
+    shz_xmtrx_store_3x3(out);
+}
+
+SHZ_INLINE void shz_mat3x3_inverse_unscaled(const shz_mat3x3_t* mtrx,
+                                 shz_mat3x3_t* out) SHZ_NOEXCEPT {
+    // the transpose gives easy access to the rows as columns
+    alignas(32) shz_mat3x3_t transpose;
+    shz_mat3x3_transpose(mtrx, &transpose);
+
+    out->col[0] = shz_vec3_cross(transpose.col[1], transpose.col[2]),
+    out->col[1] = shz_vec3_cross(transpose.col[2], transpose.col[0]),
+    out->col[2] = shz_vec3_cross(transpose.col[0], transpose.col[1]);
+}
+
+SHZ_INLINE void shz_mat3x3_inverse(const shz_mat3x3_t* mtrx,
+                        shz_mat3x3_t* out) SHZ_NOEXCEPT {
+    const float determinant =
+        shz_vec3_dot(mtrx->col[0], shz_vec3_cross(mtrx->col[1], mtrx->col[2]));
+    assert(determinant != 0.0f &&
+           "shz_mat3x3_inverse: matrix is singular and cannot be inverted");
+    const float inv_det = shz_invf(determinant);
+    shz_mat3x3_inverse_unscaled(mtrx, out);
+    for (int i = 0; i < 3; i++) {
+        out->col[i] = shz_vec3_scale(out->col[i], inv_det);
+    }
+}
+
+static void shz_mat4x4_inverse(const shz_mat4x4_t* mtrx,
+                        shz_mat4x4_t* out) SHZ_NOEXCEPT {
+    assert(mtrx != out &&
+           "shz_mat4x4_inverse: in-place inversion is not supported");
+    /**
+      If your matrix looks like this
+        A = [ M   b ]
+            [ 0   w ]
+
+      where A is 4x4, M is 3x3, b is 3x1, and the bottom row is (0,0,0,w) with
+      w != 0. For this block-triangular form, det(A) = det(M) * w. Then
+
+        inv(A) = [ inv(M)        -inv(M) * b / w ]
+                 [   0                 1/w       ]
+    */
+    if (mtrx->col[0].w == 0.0f && mtrx->col[1].w == 0.0f &&
+        mtrx->col[2].w == 0.0f && mtrx->col[3].w != 0.0f) {
+        alignas(32) shz_mat3x3_t invM;
+        shz_mat3x3_inverse(&(shz_mat3x3_t){.col[0] = mtrx->col[0].xyz,
+                                           .col[1] = mtrx->col[1].xyz,
+                                           .col[2] = mtrx->col[2].xyz},
+                           &invM);
+
+        float inv_w = mtrx->col[3].w;
+        if (inv_w != 1.0f) {
+            inv_w = shz_invf(inv_w);
+        }
+        out->col[0] = (shz_vec4_t){.xyz = invM.col[0], .w = 0.0f};
+        out->col[1] = (shz_vec4_t){.xyz = invM.col[1], .w = 0.0f};
+        out->col[2] = (shz_vec4_t){.xyz = invM.col[2], .w = 0.0f};
+        out->col[3] = (shz_vec4_t){
+            .xyz = shz_vec3_scale(
+                shz_mat3x3_trans_vec3(&invM, mtrx->col[3].xyz), -inv_w),
+            .w = inv_w};
+        return;
+    }
+    // General case for full 4x4 matrix inversion, roughly ported from cglm
+    const float c1 = shz_fmaf(mtrx->elem2D[2][2], mtrx->elem2D[3][3],
+                              -mtrx->elem2D[2][3] * mtrx->elem2D[3][2]),
+                c2 = shz_fmaf(mtrx->elem2D[0][2], mtrx->elem2D[1][3],
+                              -mtrx->elem2D[0][3] * mtrx->elem2D[1][2]),
+                c3 = shz_fmaf(mtrx->elem2D[2][0], mtrx->elem2D[3][3],
+                              -mtrx->elem2D[2][3] * mtrx->elem2D[3][0]),
+                c4 = shz_fmaf(mtrx->elem2D[0][0], mtrx->elem2D[1][3],
+                              -mtrx->elem2D[0][3] * mtrx->elem2D[1][0]),
+                c5 = shz_fmaf(mtrx->elem2D[2][1], mtrx->elem2D[3][3],
+                              -mtrx->elem2D[2][3] * mtrx->elem2D[3][1]),
+                c6 = shz_fmaf(mtrx->elem2D[0][1], mtrx->elem2D[1][3],
+                              -mtrx->elem2D[0][3] * mtrx->elem2D[1][1]),
+                c7 = shz_fmaf(mtrx->elem2D[2][0], mtrx->elem2D[3][1],
+                              -mtrx->elem2D[2][1] * mtrx->elem2D[3][0]),
+                c8 = shz_fmaf(mtrx->elem2D[0][0], mtrx->elem2D[1][1],
+                              -mtrx->elem2D[0][1] * mtrx->elem2D[1][0]),
+                c9 = shz_fmaf(mtrx->elem2D[2][1], mtrx->elem2D[3][2],
+                              -mtrx->elem2D[2][2] * mtrx->elem2D[3][1]),
+                c10 = shz_fmaf(mtrx->elem2D[0][1], mtrx->elem2D[1][2],
+                               -mtrx->elem2D[0][2] * mtrx->elem2D[1][1]),
+                c11 = shz_fmaf(mtrx->elem2D[2][0], mtrx->elem2D[3][2],
+                               -mtrx->elem2D[2][2] * mtrx->elem2D[3][0]),
+                c12 = shz_fmaf(mtrx->elem2D[0][0], mtrx->elem2D[1][2],
+                               -mtrx->elem2D[0][2] * mtrx->elem2D[1][0]),
+                inv_det = shz_invf(c8 * c1 + c4 * c9 + c10 * c3 + c2 * c7 -
+                                   c12 * c5 - c6 * c11);
+
+    out->elem2D[0][0] = +(mtrx->elem2D[1][1] * c1 - mtrx->elem2D[1][2] * c5 +
+                          mtrx->elem2D[1][3] * c9) *
+                        inv_det;
+    out->elem2D[0][1] = -(mtrx->elem2D[0][1] * c1 - mtrx->elem2D[0][2] * c5 +
+                          mtrx->elem2D[0][3] * c9) *
+                        inv_det;
+    out->elem2D[0][2] = +(mtrx->elem2D[3][1] * c2 - mtrx->elem2D[3][2] * c6 +
+                          mtrx->elem2D[3][3] * c10) *
+                        inv_det;
+    out->elem2D[0][3] = -(mtrx->elem2D[2][1] * c2 - mtrx->elem2D[2][2] * c6 +
+                          mtrx->elem2D[2][3] * c10) *
+                        inv_det;
+
+    out->elem2D[1][0] = -(mtrx->elem2D[1][0] * c1 - mtrx->elem2D[1][2] * c3 +
+                          mtrx->elem2D[1][3] * c11) *
+                        inv_det;
+    out->elem2D[1][1] = +(mtrx->elem2D[0][0] * c1 - mtrx->elem2D[0][2] * c3 +
+                          mtrx->elem2D[0][3] * c11) *
+                        inv_det;
+    out->elem2D[1][2] = -(mtrx->elem2D[3][0] * c2 - mtrx->elem2D[3][2] * c4 +
+                          mtrx->elem2D[3][3] * c12) *
+                        inv_det;
+    out->elem2D[1][3] = +(mtrx->elem2D[2][0] * c2 - mtrx->elem2D[2][2] * c4 +
+                          mtrx->elem2D[2][3] * c12) *
+                        inv_det;
+
+    out->elem2D[2][0] = +(mtrx->elem2D[1][0] * c5 - mtrx->elem2D[1][1] * c3 +
+                          mtrx->elem2D[1][3] * c7) *
+                        inv_det;
+    out->elem2D[2][1] = -(mtrx->elem2D[0][0] * c5 - mtrx->elem2D[0][1] * c3 +
+                          mtrx->elem2D[0][3] * c7) *
+                        inv_det;
+    out->elem2D[2][2] = +(mtrx->elem2D[3][0] * c6 - mtrx->elem2D[3][1] * c4 +
+                          mtrx->elem2D[3][3] * c8) *
+                        inv_det;
+    out->elem2D[2][3] = -(mtrx->elem2D[2][0] * c6 - mtrx->elem2D[2][1] * c4 +
+                          mtrx->elem2D[2][3] * c8) *
+                        inv_det;
+
+    out->elem2D[3][0] = -(mtrx->elem2D[1][0] * c9 - mtrx->elem2D[1][1] * c11 +
+                          mtrx->elem2D[1][2] * c7) *
+                        inv_det;
+    out->elem2D[3][1] = +(mtrx->elem2D[0][0] * c9 - mtrx->elem2D[0][1] * c11 +
+                          mtrx->elem2D[0][2] * c7) *
+                        inv_det;
+    out->elem2D[3][2] = -(mtrx->elem2D[3][0] * c10 - mtrx->elem2D[3][1] * c12 +
+                          mtrx->elem2D[3][2] * c8) *
+                        inv_det;
+    out->elem2D[3][3] = +(mtrx->elem2D[2][0] * c10 - mtrx->elem2D[2][1] * c12 +
+                          mtrx->elem2D[2][2] * c8) *
+                        inv_det;
+}
+
 //! \endcond


### PR DESCRIPTION
I haven't added these methods to the C++ API, and trust that the maintainer will handle that task excellently

There is no test code included, but I previously did some rough testing with something like the following:


```c
void print_mat3x3(const char *label, shz_mat3x3_t *mtx) {

  printf("Matrix3x3 %s:\n", label);
  for (int r = 0; r < 3; r++) {
    printf("| ");
    for (int c = 0; c < 3; c++) {
      printf("%10.4f |", mtx->elem2D[r][c]);
    }
    printf("\n");
  }
}

void print_mat4x4(const char *label, shz_mat4x4_t *mtx) {
  printf("Matrix4x4 %s:\n", label);
  for (int r = 0; r < 4; r++) {
    printf("| ");
    for (int c = 0; c < 4; c++) {
      printf("%10.4f |", mtx->elem2D[r][c]);
    }
    printf("\n");
  }
}

void print_xmtrx() {
  alignas(32) shz_mat4x4_t mtx = {0};
  shz_xmtrx_store_4x4(&mtx);
  printf("xmtrx -> ");
  print_mat4x4("xmtrx", &mtx);
}

void test_mat_inverse() {
    shz_mat3x3_t inv3x3 = {0};
    // test inverse transpose correctness
    shz_mat3x3_inverse(&inverse_transpose, &inv3x3);
    print_mat3x3("InverseTranspose Inverted", &inv3x3);
    shz_mat3x3_inverse(&inv3x3, &inverse_transpose);
    print_mat3x3("InverseTranspose Double Inverted", &inverse_transpose);

    shz_mat4x4_t inv4x4 = {0};
    print_mat4x4("ModelView", &modelView);
    shz_mat4x4_inverse(&modelView, &inv4x4);
    print_mat4x4("ModelView Inverted", &inv4x4);
    shz_mat4x4_inverse(&inv4x4, &modelView);
    print_mat4x4("ModelView Double Inverted", &modelView);

    shz_mat3x3_t test_3x3_inverse = {.elem2D = {
        {1.0f, 2.0f, 3.0f},
        {4.0f, 5.0f, 6.0f},
        {7.0f, 8.0f, 9.0f},
    }};
    shz_mat3x3_t test_inverse_out = {0};

    shz_mat3x3_inverse(&test_3x3_inverse, &test_inverse_out);
    print_mat3x3("Test Transpose", &test_inverse_out);
}
```