### PR TITLE
Add warnings to doxygen regarding normalization

### DIFF
--- a/include/sh4zam/shz_quat.h
+++ b/include/sh4zam/shz_quat.h
@@ -87,6 +87,8 @@ SHZ_INLINE shz_quat_t shz_quat_from_rotated_axis(shz_vec3_t v1, shz_vec3_t v2) S
 SHZ_INLINE shz_quat_t shz_quat_lerp(shz_quat_t a, shz_quat_t b, float t) SHZ_NOEXCEPT;
 
 //! Returns the quaternion that is spherically linearly interpolating \p a to \p b, by a t factor of `0.0f-1.0f`.
+//!
+//! \warning The returned quaternion is not guaranteed to be normalized due to a floating-point error. Callers should normalize the result before reuse, especially when performing repeated interpolations.
 SHZ_INLINE shz_quat_t shz_quat_slerp(shz_quat_t q, shz_quat_t p, float t) SHZ_NOEXCEPT;
 
 //! @}

--- a/include/sh4zam/shz_quat.hpp
+++ b/include/sh4zam/shz_quat.hpp
@@ -81,6 +81,8 @@ namespace shz {
         }
 
         //! Returns the quaternion that is spherically linearly interpolating \p q to \p p, by a t factor of `0.0f-1.0f`.
+	//!
+	//! \warning The returned quaternion is not guaranteed to be normalized due to a floating-point error. Callers should normalize the result before reuse, especially when performing repeated interpolations.
         SHZ_FORCE_INLINE static quat slerp(quat q, quat p, float t) noexcept {
             return shz_quat_slerp(q, p, t);
         }


### PR DESCRIPTION
Adds a small warning for people who are likely to be calling slerp a lot and may encounter the rounding errors that cause things to jank out a little bit over time.