### PR TITLE
Reverse vec angle params from sin,cos to cos,sin

### DIFF
--- a/include/sh4zam/inline/sw/shz_vector_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_vector_sw.inl.h
@@ -398,7 +398,8 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec3_from_sincos_sw(shz_sincos_t azimuth, shz_si
 }
 
 SHZ_FORCE_INLINE shz_vec2_t shz_vec2_from_angle_sw(float radians) SHZ_NOEXCEPT {
-    return shz_vec2_from_sincos(shz_sincosf(radians));
+    shz_sincos_t sc = shz_sincosf(radians);
+    return shz_vec2_init(sc.cos, sc.sin);
 }
 
 SHZ_FORCE_INLINE shz_vec3_t shz_vec3_from_angles_sw(float azimuth, float elevation) SHZ_NOEXCEPT {
@@ -406,7 +407,8 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec3_from_angles_sw(float azimuth, float elevati
 }
 
 SHZ_FORCE_INLINE shz_vec2_t shz_vec2_from_angle_deg_sw(float degrees) SHZ_NOEXCEPT {
-    return shz_vec2_from_sincos(shz_sincosf_deg(degrees));
+    shz_sincos_t sc = shz_sincosf_deg(degrees);
+    return shz_vec2_init(sc.cos, sc.sin);
 }
 
 SHZ_FORCE_INLINE shz_vec3_t shz_vec3_from_angles_deg_sw(float azimuth, float elevation) SHZ_NOEXCEPT {


### PR DESCRIPTION
Swapped around sin and cos to match the function description. Most of the major engines use 0degrees pointing towards +X. Just differ on CW or CCW.

Should give the following results for different quadrants:

shz_vec2_from_angle(0.0f) = [1.0, 0.0]
shz_vec2_from_angle_deg(90.0f) = [0.0, 1.0]
shz_vec2_from_angle(SHZ_F_PI) = [-1.0, 0.0]
shz_vec2_from_angle(3.0f*SHZ_F_PI/2.0f) = [0.0, -1.0]