### PR TITLE
Fix for using SHZ_CONVERT inside template class methods

### DIFF
--- a/include/sh4zam/shz_cdefs.h
+++ b/include/sh4zam/shz_cdefs.h
@@ -146,7 +146,7 @@
                 static_assert(sizeof(VNR) == sizeof(TNR), "SHZ_CONVERT: Cannot convert between types of differing sizes."); \
                 return reinterpret_cast<To&>(value); \
             } \
-        }.operator()<type>(from)
+        }.template operator()<type>(from)
 #endif
 //! @}
 //! \endcond


### PR DESCRIPTION
overall, all explanation in subj, compiler generates errors when SHZ_CONVERT is used inside template class functions