### PR TITLE
Step and Smoothstep Implementations

### DIFF
--- a/include/sh4zam/inline/shz_scalar.inl.h
+++ b/include/sh4zam/inline/shz_scalar.inl.h
@@ -329,4 +329,12 @@ SHZ_FORCE_INLINE float shz_randf_range(int* seed, float min, float max) SHZ_NOEX
     return shz_randf_range_sw(seed, min, max);
 }
 
+SHZ_FORCE_INLINE float shz_stepf(float edge, float x) SHZ_NOEXCEPT {
+    return shz_stepf_sw(edge, x);
+}
+
+SHZ_FORCE_INLINE float shz_smoothstepf(float edge0, float edge1, float x) SHZ_NOEXCEPT {
+    return shz_smoothstepf_sw(edge0, edge1, x);
+}
+
 //! \endcond

--- a/include/sh4zam/inline/shz_scalar.inl.h
+++ b/include/sh4zam/inline/shz_scalar.inl.h
@@ -329,12 +329,12 @@ SHZ_FORCE_INLINE float shz_randf_range(int* seed, float min, float max) SHZ_NOEX
     return shz_randf_range_sw(seed, min, max);
 }
 
-SHZ_FORCE_INLINE float shz_stepf(float edge, float x) SHZ_NOEXCEPT {
-    return shz_stepf_sw(edge, x);
+SHZ_FORCE_INLINE float shz_stepf(float x, float edge) SHZ_NOEXCEPT {
+    return shz_stepf_sw(x, edge);
 }
 
-SHZ_FORCE_INLINE float shz_smoothstepf(float edge0, float edge1, float x) SHZ_NOEXCEPT {
-    return shz_smoothstepf_sw(edge0, edge1, x);
+SHZ_FORCE_INLINE float shz_smoothstepf(float x, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_smoothstepf_sw(x, edge0, edge1);
 }
 
 //! \endcond

--- a/include/sh4zam/inline/shz_scalar.inl.h
+++ b/include/sh4zam/inline/shz_scalar.inl.h
@@ -337,4 +337,8 @@ SHZ_FORCE_INLINE float shz_smoothstepf(float x, float edge0, float edge1) SHZ_NO
     return shz_smoothstepf_sw(x, edge0, edge1);
 }
 
+SHZ_FORCE_INLINE float shz_smoothstepf_safe(float x, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_smoothstepf_safe_sw(x, edge0, edge1);
+}
+
 //! \endcond

--- a/include/sh4zam/inline/shz_vector.inl.h
+++ b/include/sh4zam/inline/shz_vector.inl.h
@@ -523,52 +523,52 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec4_dot3(shz_vec4_t l, shz_vec4_t r1, shz_vec4_
 #endif
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv(shz_vec2_t edge, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_stepv_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv(shz_vec2_t vec, shz_vec2_t edge) SHZ_NOEXCEPT {
+    return shz_vec2_stepv_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv(shz_vec3_t edge, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_stepv_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv(shz_vec3_t vec, shz_vec3_t edge) SHZ_NOEXCEPT {
+    return shz_vec3_stepv_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_stepv_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv(shz_vec4_t vec, shz_vec4_t edge) SHZ_NOEXCEPT {
+    return shz_vec4_stepv_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(float edge, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_step_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(shz_vec2_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec2_step_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(float edge, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_step_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(shz_vec3_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec3_step_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(float edge, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_step_sw(edge, vec);
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(shz_vec4_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec4_step_sw(vec, edge);
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_smoothstepv_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t vec, shz_vec2_t edge0, shz_vec2_t edge1) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstepv_sw(vec, edge0, edge1);
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_smoothstepv_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t vec, shz_vec3_t edge0, shz_vec3_t edge1) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstepv_sw(vec, edge0, edge1);
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_smoothstepv_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t vec, shz_vec4_t edge0, shz_vec4_t edge1) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstepv_sw(vec, edge0, edge1);
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_smoothstep_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(shz_vec2_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstep_sw(vec, edge0, edge1);
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_smoothstep_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(shz_vec3_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstep_sw(vec, edge0, edge1);
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_smoothstep_sw(edge0, edge1, vec);
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(shz_vec4_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstep_sw(vec, edge0, edge1);
 }
 
  //! \endcond

--- a/include/sh4zam/inline/shz_vector.inl.h
+++ b/include/sh4zam/inline/shz_vector.inl.h
@@ -571,5 +571,29 @@ SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(shz_vec4_t vec, float edge0, flo
     return shz_vec4_smoothstep_sw(vec, edge0, edge1);
 }
 
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv_safe(shz_vec2_t vec, shz_vec2_t edge0, shz_vec2_t edge1) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstepv_safe_sw(vec, edge0, edge1);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv_safe(shz_vec3_t vec, shz_vec3_t edge0, shz_vec3_t edge1) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstepv_safe_sw(vec, edge0, edge1);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv_safe(shz_vec4_t vec, shz_vec4_t edge0, shz_vec4_t edge1) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstepv_safe_sw(vec, edge0, edge1);
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep_safe(shz_vec2_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstep_safe_sw(vec, edge0, edge1);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep_safe(shz_vec3_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstep_safe_sw(vec, edge0, edge1);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_safe(shz_vec4_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstep_safe_sw(vec, edge0, edge1);
+}
+
  //! \endcond
  

--- a/include/sh4zam/inline/shz_vector.inl.h
+++ b/include/sh4zam/inline/shz_vector.inl.h
@@ -523,6 +523,53 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec4_dot3(shz_vec4_t l, shz_vec4_t r1, shz_vec4_
 #endif
 }
 
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv(shz_vec2_t edge, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_stepv_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv(shz_vec3_t edge, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_stepv_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_stepv_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(float edge, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_step_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(float edge, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_step_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(float edge, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_step_sw(edge, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstepv_sw(edge0, edge1, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstepv_sw(edge0, edge1, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstepv_sw(edge0, edge1, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_smoothstep_sw(edge0, edge1, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_smoothstep_sw(edge0, edge1, vec);
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_smoothstep_sw(edge0, edge1, vec);
+}
 
  //! \endcond
  

--- a/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
@@ -310,13 +310,13 @@ SHZ_FORCE_INLINE float shz_randf_range_sw(int* seed, float min, float max) SHZ_N
 }
 //! \endcond
 
-SHZ_FORCE_INLINE float shz_stepf_sw(float edge, float x) SHZ_NOEXCEPT {
+SHZ_FORCE_INLINE float shz_stepf_sw(float x, float edge) SHZ_NOEXCEPT {
     return (x < edge) ? 0.0f : 1.0f;
 }
 
-SHZ_FORCE_INLINE float shz_smoothstepf_sw(float edge0, float edge1, float x) SHZ_NOEXCEPT {
+SHZ_FORCE_INLINE float shz_smoothstepf_sw(float x, float edge0, float edge1) SHZ_NOEXCEPT {
     if(edge0 == edge1) {
-        return shz_stepf(edge0, x);
+        return shz_stepf(x, edge0);
     }
 
     float t = (x - edge0) / (edge1 - edge0);

--- a/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
@@ -310,4 +310,22 @@ SHZ_FORCE_INLINE float shz_randf_range_sw(int* seed, float min, float max) SHZ_N
 }
 //! \endcond
 
+SHZ_FORCE_INLINE float shz_stepf_sw(float edge, float x) SHZ_NOEXCEPT {
+    return (x < edge) ? 0.0f : 1.0f;
+}
+
+SHZ_FORCE_INLINE float shz_smoothstepf_sw(float edge0, float edge1, float x) SHZ_NOEXCEPT {
+    const float diff = edge1 - edge0;
+    const float diff_sq = diff * diff;
+    if (shz_equalf(diff, 0.0f))
+        return shz_stepf(edge0, x);
+
+    float inv_ad = shz_inv_sqrtf(diff_sq);
+    inv_ad *= inv_ad;
+
+    float t = (x - edge0) * diff * inv_ad;
+    t = shz_clampf(t, 0.0f, 1.0f);
+    return t * t * shz_fmaf(t, -2.0f, 3.0f);
+}
+
 #endif

--- a/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
@@ -308,13 +308,28 @@ SHZ_FORCE_INLINE float shz_randf_sw(int* seed) SHZ_NOEXCEPT {
 SHZ_FORCE_INLINE float shz_randf_range_sw(int* seed, float min, float max) SHZ_NOEXCEPT {
     return shz_fmaf(shz_randf(seed), max - min, min);
 }
-//! \endcond
 
 SHZ_FORCE_INLINE float shz_stepf_sw(float x, float edge) SHZ_NOEXCEPT {
     return (x < edge) ? 0.0f : 1.0f;
 }
 
 SHZ_FORCE_INLINE float shz_smoothstepf_sw(float x, float edge0, float edge1) SHZ_NOEXCEPT {
+    if (x >= edge1) return 1.0f;
+    if (x <= edge0) return 0.0f;
+    if (edge0 == edge1) {
+        return shz_stepf(x, edge0);
+    }
+
+    float diff = edge1 - edge0;
+
+    float inv_diff = shz_inv_sqrtf_fsrra(diff);
+
+    float t = (x - edge0) * inv_diff;
+    t *= inv_diff;
+    return t * t * shz_fmaf(t, -2.0f, 3.0f);
+}
+
+SHZ_FORCE_INLINE float shz_smoothstepf_safe_sw(float x, float edge0, float edge1) SHZ_NOEXCEPT {
     if(edge0 == edge1) {
         return shz_stepf(x, edge0);
     }
@@ -323,5 +338,7 @@ SHZ_FORCE_INLINE float shz_smoothstepf_sw(float x, float edge0, float edge1) SHZ
     t = shz_clampf(t, 0.0f, 1.0f);
     return t * t * shz_fmaf(t, -2.0f, 3.0f);
 }
+
+//! \endcond
 
 #endif

--- a/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
@@ -315,15 +315,11 @@ SHZ_FORCE_INLINE float shz_stepf_sw(float edge, float x) SHZ_NOEXCEPT {
 }
 
 SHZ_FORCE_INLINE float shz_smoothstepf_sw(float edge0, float edge1, float x) SHZ_NOEXCEPT {
-    const float diff = edge1 - edge0;
-    const float diff_sq = diff * diff;
-    if (shz_equalf(diff, 0.0f))
+    if(edge0 == edge1) {
         return shz_stepf(edge0, x);
+    }
 
-    float inv_ad = shz_inv_sqrtf(diff_sq);
-    inv_ad *= inv_ad;
-
-    float t = (x - edge0) * diff * inv_ad;
+    float t = (x - edge0) / (edge1 - edge0);
     t = shz_clampf(t, 0.0f, 1.0f);
     return t * t * shz_fmaf(t, -2.0f, 3.0f);
 }

--- a/include/sh4zam/inline/sw/shz_vector_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_vector_sw.inl.h
@@ -672,6 +672,42 @@ SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_sw(shz_vec4_t vec, float edge0, 
                          shz_smoothstepf(vec.w, edge0, edge1));
 }
 
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv_safe_sw(shz_vec2_t vec, shz_vec2_t edge0, shz_vec2_t edge1) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf_safe(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf_safe(vec.y, edge0.y, edge1.y));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv_safe_sw(shz_vec3_t vec, shz_vec3_t edge0, shz_vec3_t edge1) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf_safe(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf_safe(vec.y, edge0.y, edge1.y),
+                         shz_smoothstepf_safe(vec.z, edge0.z, edge1.z));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv_safe_sw(shz_vec4_t vec, shz_vec4_t edge0, shz_vec4_t edge1) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf_safe(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf_safe(vec.y, edge0.y, edge1.y),
+                         shz_smoothstepf_safe(vec.z, edge0.z, edge1.z),
+                         shz_smoothstepf_safe(vec.w, edge0.w, edge1.w));
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep_safe_sw(shz_vec2_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf_safe(vec.x, edge0, edge1),
+                         shz_smoothstepf_safe(vec.y, edge0, edge1));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep_safe_sw(shz_vec3_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf_safe(vec.x, edge0, edge1),
+                         shz_smoothstepf_safe(vec.y, edge0, edge1),
+                         shz_smoothstepf_safe(vec.z, edge0, edge1));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_safe_sw(shz_vec4_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf_safe(vec.x, edge0, edge1),
+                         shz_smoothstepf_safe(vec.y, edge0, edge1),
+                         shz_smoothstepf_safe(vec.z, edge0, edge1),
+                         shz_smoothstepf_safe(vec.w, edge0, edge1));
+}
+
 //! \endcond
 
 #endif

--- a/include/sh4zam/inline/sw/shz_vector_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_vector_sw.inl.h
@@ -600,76 +600,76 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec4_dot3_sw(shz_vec4_t l, shz_vec4_t r1, shz_ve
     return res;
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv_sw(shz_vec2_t edge, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_init(shz_stepf(edge.x, vec.x),
-                         shz_stepf(edge.y, vec.y));
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv_sw(shz_vec2_t vec, shz_vec2_t edge) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_stepf(vec.x, edge.x),
+                         shz_stepf(vec.y, edge.y));
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv_sw(shz_vec3_t edge, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_init(shz_stepf(edge.x, vec.x),
-                         shz_stepf(edge.y, vec.y),
-                         shz_stepf(edge.z, vec.z));
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv_sw(shz_vec3_t vec, shz_vec3_t edge) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_stepf(vec.x, edge.x),
+                         shz_stepf(vec.y, edge.y),
+                         shz_stepf(vec.z, edge.z));
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv_sw(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_init(shz_stepf(edge.x, vec.x),
-                         shz_stepf(edge.y, vec.y),
-                         shz_stepf(edge.z, vec.z),
-                         shz_stepf(edge.w, vec.w));
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv_sw(shz_vec4_t vec, shz_vec4_t edge) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_stepf(vec.x, edge.x),
+                         shz_stepf(vec.y, edge.y),
+                         shz_stepf(vec.z, edge.z),
+                         shz_stepf(vec.w, edge.w));
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step_sw(float edge, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_init(shz_stepf(edge, vec.x),
-                         shz_stepf(edge, vec.y));
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step_sw(shz_vec2_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_stepf(vec.x, edge),
+                         shz_stepf(vec.y, edge));
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step_sw(float edge, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_init(shz_stepf(edge, vec.x),
-                         shz_stepf(edge, vec.y),
-                         shz_stepf(edge, vec.z));
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step_sw(shz_vec3_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_stepf(vec.x, edge),
+                         shz_stepf(vec.y, edge),
+                         shz_stepf(vec.z, edge));
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step_sw(float edge, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_init(shz_stepf(edge, vec.x),
-                         shz_stepf(edge, vec.y),
-                         shz_stepf(edge, vec.z),
-                         shz_stepf(edge, vec.w));
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step_sw(shz_vec4_t vec, float edge) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_stepf(vec.x, edge),
+                         shz_stepf(vec.y, edge),
+                         shz_stepf(vec.z, edge),
+                         shz_stepf(vec.w, edge));
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv_sw(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
-                         shz_smoothstepf(edge0.y, edge1.y, vec.y));
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv_sw(shz_vec2_t vec, shz_vec2_t edge0, shz_vec2_t edge1) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf(vec.y, edge0.y, edge1.y));
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv_sw(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
-                         shz_smoothstepf(edge0.y, edge1.y, vec.y),
-                         shz_smoothstepf(edge0.z, edge1.z, vec.z));
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv_sw(shz_vec3_t vec, shz_vec3_t edge0, shz_vec3_t edge1) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf(vec.y, edge0.y, edge1.y),
+                         shz_smoothstepf(vec.z, edge0.z, edge1.z));
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv_sw(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
-                         shz_smoothstepf(edge0.y, edge1.y, vec.y),
-                         shz_smoothstepf(edge0.z, edge1.z, vec.z),
-                         shz_smoothstepf(edge0.w, edge1.w, vec.w));
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv_sw(shz_vec4_t vec, shz_vec4_t edge0, shz_vec4_t edge1) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf(vec.x, edge0.x, edge1.x),
+                         shz_smoothstepf(vec.y, edge0.y, edge1.y),
+                         shz_smoothstepf(vec.z, edge0.z, edge1.z),
+                         shz_smoothstepf(vec.w, edge0.w, edge1.w));
 }
 
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep_sw(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
-    return shz_vec2_init(shz_smoothstepf(edge0, edge1, vec.x),
-                         shz_smoothstepf(edge0, edge1, vec.y));
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep_sw(shz_vec2_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf(vec.x, edge0, edge1),
+                         shz_smoothstepf(vec.y, edge0, edge1));
 }
 
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep_sw(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
-    return shz_vec3_init(shz_smoothstepf(edge0, edge1, vec.x),
-                         shz_smoothstepf(edge0, edge1, vec.y),
-                         shz_smoothstepf(edge0, edge1, vec.z));
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep_sw(shz_vec3_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf(vec.x, edge0, edge1),
+                         shz_smoothstepf(vec.y, edge0, edge1),
+                         shz_smoothstepf(vec.z, edge0, edge1));
 }
 
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_sw(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
-    return shz_vec4_init(shz_smoothstepf(edge0, edge1, vec.x),
-                         shz_smoothstepf(edge0, edge1, vec.y),
-                         shz_smoothstepf(edge0, edge1, vec.z),
-                         shz_smoothstepf(edge0, edge1, vec.w));
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_sw(shz_vec4_t vec, float edge0, float edge1) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf(vec.x, edge0, edge1),
+                         shz_smoothstepf(vec.y, edge0, edge1),
+                         shz_smoothstepf(vec.z, edge0, edge1),
+                         shz_smoothstepf(vec.w, edge0, edge1));
 }
 
 //! \endcond

--- a/include/sh4zam/inline/sw/shz_vector_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_vector_sw.inl.h
@@ -599,6 +599,79 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec4_dot3_sw(shz_vec4_t l, shz_vec4_t r1, shz_ve
                                    shz_vec4_dot(l, r3));
     return res;
 }
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv_sw(shz_vec2_t edge, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_stepf(edge.x, vec.x),
+                         shz_stepf(edge.y, vec.y));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv_sw(shz_vec3_t edge, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_stepf(edge.x, vec.x),
+                         shz_stepf(edge.y, vec.y),
+                         shz_stepf(edge.z, vec.z));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv_sw(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_stepf(edge.x, vec.x),
+                         shz_stepf(edge.y, vec.y),
+                         shz_stepf(edge.z, vec.z),
+                         shz_stepf(edge.w, vec.w));
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step_sw(float edge, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_stepf(edge, vec.x),
+                         shz_stepf(edge, vec.y));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step_sw(float edge, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_stepf(edge, vec.x),
+                         shz_stepf(edge, vec.y),
+                         shz_stepf(edge, vec.z));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step_sw(float edge, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_stepf(edge, vec.x),
+                         shz_stepf(edge, vec.y),
+                         shz_stepf(edge, vec.z),
+                         shz_stepf(edge, vec.w));
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv_sw(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
+                         shz_smoothstepf(edge0.y, edge1.y, vec.y));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv_sw(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
+                         shz_smoothstepf(edge0.y, edge1.y, vec.y),
+                         shz_smoothstepf(edge0.z, edge1.z, vec.z));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv_sw(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf(edge0.x, edge1.y, vec.x),
+                         shz_smoothstepf(edge0.y, edge1.y, vec.y),
+                         shz_smoothstepf(edge0.z, edge1.z, vec.z),
+                         shz_smoothstepf(edge0.w, edge1.w, vec.w));
+}
+
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep_sw(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT {
+    return shz_vec2_init(shz_smoothstepf(edge0, edge1, vec.x),
+                         shz_smoothstepf(edge0, edge1, vec.y));
+}
+
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep_sw(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT {
+    return shz_vec3_init(shz_smoothstepf(edge0, edge1, vec.x),
+                         shz_smoothstepf(edge0, edge1, vec.y),
+                         shz_smoothstepf(edge0, edge1, vec.z));
+}
+
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep_sw(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT {
+    return shz_vec4_init(shz_smoothstepf(edge0, edge1, vec.x),
+                         shz_smoothstepf(edge0, edge1, vec.y),
+                         shz_smoothstepf(edge0, edge1, vec.z),
+                         shz_smoothstepf(edge0, edge1, vec.w));
+}
+
 //! \endcond
 
 #endif

--- a/include/sh4zam/shz_scalar.h
+++ b/include/sh4zam/shz_scalar.h
@@ -241,8 +241,11 @@ SHZ_FORCE_INLINE float shz_randf_range(int* seed, float min, float max) SHZ_NOEX
 //! returns 0.0f if x < edge, otherwise 1.0f
 SHZ_FORCE_INLINE float shz_stepf(float edge, float x) SHZ_NOEXCEPT;
 
-//! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
+//! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between. edge0 must be less than edge1 or result is undefined.
 SHZ_FORCE_INLINE float shz_smoothstepf(float edge0, float edge1, float x) SHZ_NOEXCEPT;
+
+//! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between. Accepts inverse edges.
+SHZ_FORCE_INLINE float shz_smoothstepf_safe(float edge0, float edge1, float x) SHZ_NOEXCEPT;
 
 //! @}
 

--- a/include/sh4zam/shz_scalar.h
+++ b/include/sh4zam/shz_scalar.h
@@ -238,6 +238,12 @@ SHZ_FORCE_INLINE float shz_randf(int* seed) SHZ_NOEXCEPT;
 //! Returns a random floating-point number between \p min and \p max, using and updating the given seed.
 SHZ_FORCE_INLINE float shz_randf_range(int* seed, float min, float max) SHZ_NOEXCEPT;
 
+//! returns 0.0f if x < edge, otherwise 1.0f
+SHZ_FORCE_INLINE float shz_stepf(float edge, float x) SHZ_NOEXCEPT;
+
+//! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
+SHZ_FORCE_INLINE float shz_smoothstepf(float edge0, float edge1, float x) SHZ_NOEXCEPT;
+
 //! @}
 
 /*! \name  FSRRA

--- a/include/sh4zam/shz_scalar.hpp
+++ b/include/sh4zam/shz_scalar.hpp
@@ -101,6 +101,8 @@ namespace shz {
     constexpr auto stepf             = shz_stepf;
     //! C++ alias for shz_smoothstepf()
     constexpr auto smoothstepf       = shz_smoothstepf;
+    //! C++ alias for shz_smoothstepf_safe()
+    constexpr auto smoothstepf_safe  = shz_smoothstepf_safe;
 
     //! @}
 

--- a/include/sh4zam/shz_scalar.hpp
+++ b/include/sh4zam/shz_scalar.hpp
@@ -97,6 +97,11 @@ namespace shz {
     constexpr auto randf             = shz_randf;
     //! C++ alias for shz_randf_range()
     constexpr auto randf_range       = shz_randf_range;
+    //! C++ alias for shz_stepf()
+    constexpr auto stepf             = shz_stepf;
+    //! C++ alias for shz_smoothstepf()
+    constexpr auto smoothstepf       = shz_smoothstepf;
+
     //! @}
 
     /*! \name  FSRRA

--- a/include/sh4zam/shz_vector.h
+++ b/include/sh4zam/shz_vector.h
@@ -839,29 +839,47 @@ SHZ_DECLS_END
                  shz_vec3_t: shz_vec3_swizzle, \
                  shz_vec4_t: shz_vec4_swizzle)(vec, __VA_ARGS__)
 
+    //! C type-generic component-wise step
 #   define shz_vec_stepv(vec, edge) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_stepv, \
                  shz_vec3_t: shz_vec3_stepv, \
                  shz_vec4_t: shz_vec4_stepv)(vec, edge)
 
+    //! C type-generic step
 #   define shz_vec_step(vec, edge) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_step, \
                  shz_vec3_t: shz_vec3_step, \
                  shz_vec4_t: shz_vec4_step)(vec, edge)
 
+    //! C type-generic component-wise smoothstep
 #   define shz_vec_smoothstepv(vec, edge0, edge1) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_smoothstepv, \
                  shz_vec3_t: shz_vec3_smoothstepv, \
                  shz_vec4_t: shz_vec4_smoothstepv)(vec, edge0, edge1)
 
+    //! C type-generic smoothstep
 #   define shz_vec_smoothstep(vec, edge0, edge1) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_smoothstep, \
                  shz_vec3_t: shz_vec3_smoothstep, \
                  shz_vec4_t: shz_vec4_smoothstep)(vec, edge0, edge1)
+
+    //! C type-generic component-wise smoothstep_safe
+#   define shz_vec_smoothstepv_safe(vec, edge0, edge1) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_smoothstepv_safe, \
+                 shz_vec3_t: shz_vec3_smoothstepv_safe, \
+                 shz_vec4_t: shz_vec4_smoothstepv_safe)(vec, edge0, edge1)
+
+    //! C type-generic smoothstep_safe
+#   define shz_vec_smoothstep_safe(vec, edge0, edge1) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_smoothstep_safe, \
+                 shz_vec3_t: shz_vec3_smoothstep_safe, \
+                 shz_vec4_t: shz_vec4_smoothstep_safe)(vec, edge0, edge1)
 
 #else // C++ generics (because it's too dumb to support _Generic()).
 
@@ -1248,7 +1266,7 @@ SHZ_DECLS_END
         return shz_vec4_swizzle(vec, x_idx, y_idx, z_idx, w_idx);
     }
 
-    //! 
+    //! Compares each component of the vector to the edge. 0 returned in that component if x[i] < edge. Otherwise the component is 1.
     template<typename V, typename T>
     SHZ_FORCE_INLINE V shz_vec_step(V vec, T edge) SHZ_NOEXCEPT {
         constexpr bool scalar = std::is_same_v<T, float>;
@@ -1274,6 +1292,7 @@ SHZ_DECLS_END
         } else static_assert(false, "Incompatible type!");
     }
 
+    //! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between. Undefined for \p edge0 > \p edge1
     template<typename V, typename T>
     SHZ_FORCE_INLINE V shz_vec_smoothstep(V vec, T edge0, T edge1) SHZ_NOEXCEPT {
         constexpr bool scalar = std::is_same_v<T, float>;
@@ -1296,6 +1315,32 @@ SHZ_DECLS_END
                 return shz_vec4_smoothstep(vec, edge0, edge1);
             else
                 return shz_vec4_smoothstepv(vec, edge0, edge1);
+        } else static_assert(false, "Incompatible type!");
+    }
+
+    //! Returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between. Accepts inverse edges.
+    template<typename V, typename T>
+    SHZ_FORCE_INLINE V shz_vec_smoothstep_safe(V vec, T edge0, T edge1) SHZ_NOEXCEPT {
+        constexpr bool scalar = std::is_same_v<T, float>;
+        constexpr bool vector = std::is_same_v<T, V>;
+
+        static_assert(scalar || vector, "Incompatible type!");
+
+        if constexpr (std::convertible_to<V, shz_vec2_t>) {
+            if constexpr (scalar)
+                return shz_vec2_smoothstep_safe(vec, edge0, edge1);
+            else
+                return shz_vec2_smoothstepv_safe(vec, edge0, edge1);
+        } else if constexpr (std::convertible_to<V, shz_vec3_t>) {
+            if constexpr (scalar)
+                return shz_vec3_smoothstep_safe(vec, edge0, edge1);
+            else
+                return shz_vec3_smoothstepv_safe(vec, edge0, edge1);
+        } else if constexpr (std::convertible_to<V, shz_vec4_t>) {
+            if constexpr (scalar)
+                return shz_vec4_smoothstep_safe(vec, edge0, edge1);
+            else
+                return shz_vec4_smoothstepv_safe(vec, edge0, edge1);
         } else static_assert(false, "Incompatible type!");
     }
 

--- a/include/sh4zam/shz_vector.h
+++ b/include/sh4zam/shz_vector.h
@@ -197,6 +197,42 @@ SHZ_FORCE_INLINE bool shz_vec3_equal(shz_vec3_t a, shz_vec3_t b) SHZ_NOEXCEPT;
 //! Returns true if the values of each element within the two 4D vectors are approximately equal based on relative or absolute tolerance.
 SHZ_FORCE_INLINE bool shz_vec4_equal(shz_vec4_t a, shz_vec4_t b) SHZ_NOEXCEPT;
 
+//! For each component: returns 0.0f if vec[i] < edge[i], otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_stepv(shz_vec2_t edge, shz_vec2_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f if vec[i] < edge[i], otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv(shz_vec3_t edge, shz_vec3_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f if vec[i] < edge[i], otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(float edge, shz_vec2_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(float edge, shz_vec3_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(float edge, shz_vec4_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT;
+
+//! For each component i: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT;
+
+//! For each component i: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between.
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT;
+
+//! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT;
+
 //! @}
 
 /*! \name   Arithmetic
@@ -803,6 +839,30 @@ SHZ_DECLS_END
                  shz_vec3_t: shz_vec3_swizzle, \
                  shz_vec4_t: shz_vec4_swizzle)(vec, __VA_ARGS__)
 
+#   define shz_vec_stepv(edge, vec) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_stepv, \
+                 shz_vec3_t: shz_vec3_stepv, \
+                 shz_vec4_t: shz_vec4_stepv)(edge, vec)
+
+#   define shz_vec_step(edge, vec) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_step, \
+                 shz_vec3_t: shz_vec3_step, \
+                 shz_vec4_t: shz_vec4_step)(edge, vec)
+
+#   define shz_vec_smoothstepv(edge0, edge1, vec) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_smoothstepv, \
+                 shz_vec3_t: shz_vec3_smoothstepv, \
+                 shz_vec4_t: shz_vec4_smoothstepv)(edge0, edge1, vec)
+
+#   define shz_vec_smoothstep(edge0, edge1, vec) \
+        _Generic((vec), \
+                 shz_vec2_t: shz_vec2_smoothstep, \
+                 shz_vec3_t: shz_vec3_smoothstep, \
+                 shz_vec4_t: shz_vec4_smoothstep)(edge0, edge1, vec)
+
 #else // C++ generics (because it's too dumb to support _Generic()).
 
 #   include <concepts>
@@ -1187,6 +1247,58 @@ SHZ_DECLS_END
     SHZ_FORCE_INLINE shz_vec4_t shz_vec_swizzle(shz_vec4_t vec, unsigned x_idx, unsigned y_idx, unsigned z_idx, unsigned w_idx) SHZ_NOEXCEPT {
         return shz_vec4_swizzle(vec, x_idx, y_idx, z_idx, w_idx);
     }
+
+    //! 
+    template<typename T, typename V>
+    SHZ_FORCE_INLINE V shz_vec_step(T edge, V vec) SHZ_NOEXCEPT {
+        constexpr bool scalar = std::is_same_v<T, float>;
+        constexpr bool vector = std::is_same_v<T, V>;
+
+        static_assert(scalar || vector, "Incompatible type!");
+
+        if constexpr(std::convertible_to<V, shz_vec2_t>) {
+            if constexpr(scalar)
+                return shz_vec2_step(edge, vec);
+            else
+                return shz_vec2_stepv(edge, vec);
+        } else if constexpr(std::convertible_to<V, shz_vec3_t>) {
+            if constexpr(scalar)
+                return shz_vec3_step(edge, vec);
+            else
+                return shz_vec3_stepv(edge, vec);
+        } else if constexpr(std::convertible_to<V, shz_vec4_t>) {
+            if constexpr(scalar)
+                return shz_vec4_step(edge, vec);
+            else
+                return shz_vec4_stepv(edge, vec);
+        } else static_assert(false, "Incompatible type!");
+    }
+
+    template<typename T, typename V>
+    SHZ_FORCE_INLINE V shz_vec_smoothstep(T edge0, T edge1, V vec) SHZ_NOEXCEPT {
+        constexpr bool scalar = std::is_same_v<T, float>;
+        constexpr bool vector = std::is_same_v<T, V>;
+
+        static_assert(scalar || vector, "Incompatible type!");
+
+        if constexpr (std::convertible_to<V, shz_vec2_t>) {
+            if constexpr (scalar)
+                return shz_vec2_smoothstep(edge0, edge1, vec);
+            else
+                return shz_vec2_smoothstepv(edge0, edge1, vec);
+        } else if constexpr (std::convertible_to<V, shz_vec3_t>) {
+            if constexpr (scalar)
+                return shz_vec3_smoothstep(edge0, edge1, vec);
+            else
+                return shz_vec3_smoothstepv(edge0, edge1, vec);
+        } else if constexpr (std::convertible_to<V, shz_vec4_t>) {
+            if constexpr (scalar)
+                return shz_vec4_smoothstep(edge0, edge1, vec);
+            else
+                return shz_vec4_smoothstepv(edge0, edge1, vec);
+        } else static_assert(false, "Incompatible type!");
+    }
+
 #endif
 
 #include "inline/shz_vector.inl.h"

--- a/include/sh4zam/shz_vector.h
+++ b/include/sh4zam/shz_vector.h
@@ -207,31 +207,31 @@ SHZ_FORCE_INLINE shz_vec3_t shz_vec3_stepv(shz_vec3_t edge, shz_vec3_t vec) SHZ_
 SHZ_FORCE_INLINE shz_vec4_t shz_vec4_stepv(shz_vec4_t edge, shz_vec4_t vec) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(float edge, shz_vec2_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_step(shz_vec2_t vec, float edge) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(float edge, shz_vec3_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_step(shz_vec3_t vec, float edge) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f if vec[i] < edge, otherwise 1.0f
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(float edge, shz_vec4_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_step(shz_vec4_t vec, float edge) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t edge0, shz_vec2_t edge1, shz_vec2_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstepv(shz_vec2_t vec, shz_vec2_t edge0, shz_vec2_t edge1) SHZ_NOEXCEPT;
 
 //! For each component i: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t edge0, shz_vec3_t edge1, shz_vec3_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstepv(shz_vec3_t vec, shz_vec3_t edge0, shz_vec3_t edge1) SHZ_NOEXCEPT;
 
 //! For each component i: returns 0.0f at/below edge0[i], 1.0f at/above edge1[i], smoothly varying in-between.
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t edge0, shz_vec4_t edge1, shz_vec4_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstepv(shz_vec4_t vec, shz_vec4_t edge0, shz_vec4_t edge1) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between.
-SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(float edge0, float edge1, shz_vec2_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec2_t shz_vec2_smoothstep(shz_vec2_t vec, float edge0, float edge1) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
-SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(float edge0, float edge1, shz_vec3_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec3_t shz_vec3_smoothstep(shz_vec3_t vec, float edge0, float edge1) SHZ_NOEXCEPT;
 
 //! For each component: returns 0.0f at/below edge0, 1.0f at/above edge1, smoothly varying in-between
-SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(float edge0, float edge1, shz_vec4_t vec) SHZ_NOEXCEPT;
+SHZ_FORCE_INLINE shz_vec4_t shz_vec4_smoothstep(shz_vec4_t vec, float edge0, float edge1) SHZ_NOEXCEPT;
 
 //! @}
 
@@ -839,29 +839,29 @@ SHZ_DECLS_END
                  shz_vec3_t: shz_vec3_swizzle, \
                  shz_vec4_t: shz_vec4_swizzle)(vec, __VA_ARGS__)
 
-#   define shz_vec_stepv(edge, vec) \
+#   define shz_vec_stepv(vec, edge) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_stepv, \
                  shz_vec3_t: shz_vec3_stepv, \
-                 shz_vec4_t: shz_vec4_stepv)(edge, vec)
+                 shz_vec4_t: shz_vec4_stepv)(vec, edge)
 
-#   define shz_vec_step(edge, vec) \
+#   define shz_vec_step(vec, edge) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_step, \
                  shz_vec3_t: shz_vec3_step, \
-                 shz_vec4_t: shz_vec4_step)(edge, vec)
+                 shz_vec4_t: shz_vec4_step)(vec, edge)
 
-#   define shz_vec_smoothstepv(edge0, edge1, vec) \
+#   define shz_vec_smoothstepv(vec, edge0, edge1) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_smoothstepv, \
                  shz_vec3_t: shz_vec3_smoothstepv, \
-                 shz_vec4_t: shz_vec4_smoothstepv)(edge0, edge1, vec)
+                 shz_vec4_t: shz_vec4_smoothstepv)(vec, edge0, edge1)
 
-#   define shz_vec_smoothstep(edge0, edge1, vec) \
+#   define shz_vec_smoothstep(vec, edge0, edge1) \
         _Generic((vec), \
                  shz_vec2_t: shz_vec2_smoothstep, \
                  shz_vec3_t: shz_vec3_smoothstep, \
-                 shz_vec4_t: shz_vec4_smoothstep)(edge0, edge1, vec)
+                 shz_vec4_t: shz_vec4_smoothstep)(vec, edge0, edge1)
 
 #else // C++ generics (because it's too dumb to support _Generic()).
 
@@ -1249,8 +1249,8 @@ SHZ_DECLS_END
     }
 
     //! 
-    template<typename T, typename V>
-    SHZ_FORCE_INLINE V shz_vec_step(T edge, V vec) SHZ_NOEXCEPT {
+    template<typename V, typename T>
+    SHZ_FORCE_INLINE V shz_vec_step(V vec, T edge) SHZ_NOEXCEPT {
         constexpr bool scalar = std::is_same_v<T, float>;
         constexpr bool vector = std::is_same_v<T, V>;
 
@@ -1258,24 +1258,24 @@ SHZ_DECLS_END
 
         if constexpr(std::convertible_to<V, shz_vec2_t>) {
             if constexpr(scalar)
-                return shz_vec2_step(edge, vec);
+                return shz_vec2_step(vec, edge);
             else
-                return shz_vec2_stepv(edge, vec);
+                return shz_vec2_stepv(vec, edge);
         } else if constexpr(std::convertible_to<V, shz_vec3_t>) {
             if constexpr(scalar)
-                return shz_vec3_step(edge, vec);
+                return shz_vec3_step(vec, edge);
             else
-                return shz_vec3_stepv(edge, vec);
+                return shz_vec3_stepv(vec, edge);
         } else if constexpr(std::convertible_to<V, shz_vec4_t>) {
             if constexpr(scalar)
-                return shz_vec4_step(edge, vec);
+                return shz_vec4_step(vec, edge);
             else
-                return shz_vec4_stepv(edge, vec);
+                return shz_vec4_stepv(vec, edge);
         } else static_assert(false, "Incompatible type!");
     }
 
-    template<typename T, typename V>
-    SHZ_FORCE_INLINE V shz_vec_smoothstep(T edge0, T edge1, V vec) SHZ_NOEXCEPT {
+    template<typename V, typename T>
+    SHZ_FORCE_INLINE V shz_vec_smoothstep(V vec, T edge0, T edge1) SHZ_NOEXCEPT {
         constexpr bool scalar = std::is_same_v<T, float>;
         constexpr bool vector = std::is_same_v<T, V>;
 
@@ -1283,19 +1283,19 @@ SHZ_DECLS_END
 
         if constexpr (std::convertible_to<V, shz_vec2_t>) {
             if constexpr (scalar)
-                return shz_vec2_smoothstep(edge0, edge1, vec);
+                return shz_vec2_smoothstep(vec, edge0, edge1);
             else
-                return shz_vec2_smoothstepv(edge0, edge1, vec);
+                return shz_vec2_smoothstepv(vec, edge0, edge1);
         } else if constexpr (std::convertible_to<V, shz_vec3_t>) {
             if constexpr (scalar)
-                return shz_vec3_smoothstep(edge0, edge1, vec);
+                return shz_vec3_smoothstep(vec, edge0, edge1);
             else
-                return shz_vec3_smoothstepv(edge0, edge1, vec);
+                return shz_vec3_smoothstepv(vec, edge0, edge1);
         } else if constexpr (std::convertible_to<V, shz_vec4_t>) {
             if constexpr (scalar)
-                return shz_vec4_smoothstep(edge0, edge1, vec);
+                return shz_vec4_smoothstep(vec, edge0, edge1);
             else
-                return shz_vec4_smoothstepv(edge0, edge1, vec);
+                return shz_vec4_smoothstepv(vec, edge0, edge1);
         } else static_assert(false, "Incompatible type!");
     }
 

--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -75,6 +75,18 @@ struct vecN: C {
         return shz_vec_lerp(start, end, t);
     }
 
+    //! Compares each component of the vector to the edge. 0 returned in that component if x[i] < edge. Otherwise the component is 1.
+    template<typename T>
+    SHZ_FORCE_INLINE static CppType step(T edge, CppType vec) noexcept {
+        return shz_vec_step(edge, vec);
+    }
+
+    //! Returns a vector where each component is smoothly interpolated from 0 to 1 between edge0 and edge1.
+    template<typename T>
+    SHZ_FORCE_INLINE static CppType smoothstep(T edge0, T edge1, CppType vec) noexcept {
+        return shz_vec_smoothstep(edge0, edge1, vec);
+    }
+
 #ifdef SHZ_CPP23
     //! Overloaded subscript operator -- allows for indexing vectors like an array.
     SHZ_FORCE_INLINE auto&& operator[](this auto&& self, size_t index) noexcept {

--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -77,14 +77,14 @@ struct vecN: C {
 
     //! Compares each component of the vector to the edge. 0 returned in that component if x[i] < edge. Otherwise the component is 1.
     template<typename T>
-    SHZ_FORCE_INLINE static CppType step(T edge, CppType vec) noexcept {
-        return shz_vec_step(edge, vec);
+    SHZ_FORCE_INLINE static CppType step(CppType vec, T edge) noexcept {
+        return shz_vec_step(vec, edge);
     }
 
     //! Returns a vector where each component is smoothly interpolated from 0 to 1 between edge0 and edge1.
     template<typename T>
-    SHZ_FORCE_INLINE static CppType smoothstep(T edge0, T edge1, CppType vec) noexcept {
-        return shz_vec_smoothstep(edge0, edge1, vec);
+    SHZ_FORCE_INLINE static CppType smoothstep(CppType vec, T edge0, T edge1) noexcept {
+        return shz_vec_smoothstep(vec, edge0, edge1);
     }
 
 #ifdef SHZ_CPP23

--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -87,6 +87,12 @@ struct vecN: C {
         return shz_vec_smoothstep(vec, edge0, edge1);
     }
 
+    //! Returns a vector where each component is smoothly interpolated from 0 to 1 between edge0 and edge1.
+    template<typename T>
+    SHZ_FORCE_INLINE static CppType smoothstep_safe(CppType vec, T edge0, T edge1) noexcept {
+        return shz_vec_smoothstep_safe(vec, edge0, edge1);
+    }
+
 #ifdef SHZ_CPP23
     //! Overloaded subscript operator -- allows for indexing vectors like an array.
     SHZ_FORCE_INLINE auto&& operator[](this auto&& self, size_t index) noexcept {

--- a/test/shz_scalar_test_suite.cpp
+++ b/test/shz_scalar_test_suite.cpp
@@ -224,6 +224,84 @@ GBL_TEST_CASE(mag_sqr4f)
     GBL_TEST_VERIFY(test({-1.0f,   0.0f, 3.333f, -4.4345f}));
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(stepf)
+    GBL_TEST_VERIFY(shz::stepf(1.0f, 1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0f, 1.0f) == 1.0f);
+
+    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.5f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.5f, 1.0f) == 1.0f);
+
+    GBL_TEST_VERIFY(shz::stepf(0.0001f, 0.0001f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0001f, 0.0002f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0002f, 0.0001f) == 0.0f);
+
+    // Negatives
+    GBL_TEST_VERIFY(shz::stepf(-1.0f, -2.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(-1.0f, -1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(-1.0f,  0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf( 0.0f, -1.0f) == 0.0f);
+
+    // Signed Zero
+    GBL_TEST_VERIFY(shz::stepf( 0.0f, -0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(-0.0f,  0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(-0.0f, -0.0f) == 1.0f);
+
+    // Denormals
+    GBL_TEST_VERIFY(shz::stepf(0.0f, std::numeric_limits<float>::denorm_min()) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(std::numeric_limits<float>::denorm_min(), 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(std::numeric_limits<float>::denorm_min(), std::numeric_limits<float>::denorm_min()) == 1.0f);
+
+    // NaN and INFINITE
+#if !defined(__FAST_MATH__) && (!defined(__FINITE_MATH_ONLY__) || (__FINITE_MATH_ONLY__ == 0))
+    GBL_TEST_VERIFY(shz::stepf(NAN, NAN) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.1f, NAN) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(NAN, 0.1f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(INFINITY, INFINITY));
+    GBL_TEST_VERIFY(shz::stepf(0.1f, INFINITY));
+    GBL_TEST_VERIFY(shz::stepf(INFINITY, 0.1f));
+#endif
+
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(smoothstepf)
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, -1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  2.0f) == 1.0f);
+
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.5f) == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.25f) == 0.15625f);// 5/32
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.75f) == 0.84375f);// 27/32
+
+    // Reversed edges (undefined in spec)
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, -1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  2.0f) == 0.0f);
+
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.5f)  == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.25f) == 0.84375f); // 27/32
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.75f) == 0.15625f); // 5/32
+
+    // Degenerate edges
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 1.0f, 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 1.0f, 1.0f) == 1.0f);
+
+    // Test edges and midpoint
+    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 2.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 4.0f) == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 6.0f) == 1.0f);
+
+    // Ensure monotonic
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.25f) < shz::smoothstepf(0.0f, 1.0f, 0.5f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.5f)  < shz::smoothstepf(0.0f, 1.0f, 0.75f));
+
+    // Mirrored monotonic
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.25f) > shz::smoothstepf(1.0f, 0.0f, 0.5f));
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.5f)  > shz::smoothstepf(1.0f, 0.0f, 0.75f));
+GBL_TEST_CASE_END
+
 GBL_TEST_REGISTER(min,
                   max,
                   clamp,
@@ -240,4 +318,6 @@ GBL_TEST_REGISTER(min,
                   dot6f,
                   dot8f,
                   mag_sqr3f,
-                  mag_sqr4f)
+                  mag_sqr4f,
+                  stepf,
+                  smoothstepf)

--- a/test/shz_scalar_test_suite.cpp
+++ b/test/shz_scalar_test_suite.cpp
@@ -226,80 +226,80 @@ GBL_TEST_CASE_END
 
 GBL_TEST_CASE(stepf)
     GBL_TEST_VERIFY(shz::stepf(1.0f, 1.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.0f) == 0.0f);
-    GBL_TEST_VERIFY(shz::stepf(0.0f, 1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0f, 1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.0f) == 1.0f);
 
-    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.5f) == 0.0f);
-    GBL_TEST_VERIFY(shz::stepf(0.5f, 1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.5f, 1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(1.0f, 0.5f) == 1.0f);
 
     GBL_TEST_VERIFY(shz::stepf(0.0001f, 0.0001f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(0.0001f, 0.0002f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(0.0002f, 0.0001f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0002f, 0.0001f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0001f, 0.0002f) == 0.0f);
 
     // Negatives
-    GBL_TEST_VERIFY(shz::stepf(-1.0f, -2.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(-2.0f, -1.0f) == 0.0f);
     GBL_TEST_VERIFY(shz::stepf(-1.0f, -1.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(-1.0f,  0.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf( 0.0f, -1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0f, -1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(-1.0f, 0.0f) == 0.0f);
 
     // Signed Zero
-    GBL_TEST_VERIFY(shz::stepf( 0.0f, -0.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(-0.0f,  0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(-0.0f, 0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0f, -0.0f) == 1.0f);
     GBL_TEST_VERIFY(shz::stepf(-0.0f, -0.0f) == 1.0f);
 
     // Denormals
-    GBL_TEST_VERIFY(shz::stepf(0.0f, std::numeric_limits<float>::denorm_min()) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(std::numeric_limits<float>::denorm_min(), 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::stepf(std::numeric_limits<float>::denorm_min(), 0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.0f, std::numeric_limits<float>::denorm_min()) == 0.0f);
     GBL_TEST_VERIFY(shz::stepf(std::numeric_limits<float>::denorm_min(), std::numeric_limits<float>::denorm_min()) == 1.0f);
 
     // NaN and INFINITE
 #if !defined(__FAST_MATH__) && (!defined(__FINITE_MATH_ONLY__) || (__FINITE_MATH_ONLY__ == 0))
     GBL_TEST_VERIFY(shz::stepf(NAN, NAN) == 1.0f);
-    GBL_TEST_VERIFY(shz::stepf(0.1f, NAN) == 1.0f);
     GBL_TEST_VERIFY(shz::stepf(NAN, 0.1f) == 1.0f);
+    GBL_TEST_VERIFY(shz::stepf(0.1f, NAN) == 1.0f);
     GBL_TEST_VERIFY(shz::stepf(INFINITY, INFINITY));
-    GBL_TEST_VERIFY(shz::stepf(0.1f, INFINITY));
     GBL_TEST_VERIFY(shz::stepf(INFINITY, 0.1f));
+    GBL_TEST_VERIFY(shz::stepf(0.1f, INFINITY));
 #endif
 
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(smoothstepf)
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, -1.0f) == 0.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  0.0f) == 0.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  1.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f,  2.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(-1.0f, 0.0f, 1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 0.0f, 0.0f, 1.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 1.0f, 0.0f, 1.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 2.0f, 0.0f, 1.0f) == 1.0f);
 
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.5f) == 0.5f);
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.25f) == 0.15625f);// 5/32
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.75f) == 0.84375f);// 27/32
+    GBL_TEST_VERIFY(shz::smoothstepf(0.5f, 0.0f, 1.0f) == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.25f, 0.0f, 1.0f) == 0.15625f); // 5/32
+    GBL_TEST_VERIFY(shz::smoothstepf(0.75f, 0.0f, 1.0f) == 0.84375f); // 27/32
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, -1.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  0.0f) == 1.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  1.0f) == 0.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f,  2.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(-1.0f, 1.0f, 0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 0.0f, 1.0f, 0.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 1.0f, 1.0f, 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf( 2.0f, 1.0f, 0.0f) == 0.0f);
 
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.5f)  == 0.5f);
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.25f) == 0.84375f); // 27/32
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.75f) == 0.15625f); // 5/32
+    GBL_TEST_VERIFY(shz::smoothstepf(0.5f, 1.0f, 0.0f) == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.25f, 1.0f, 0.0f) == 0.84375f); // 27/32
+    GBL_TEST_VERIFY(shz::smoothstepf(0.75f, 1.0f, 0.0f) == 0.15625f); // 5/32
 
     // Degenerate edges
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 1.0f, 0.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 1.0f) == 0.0f);
     GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 1.0f, 1.0f) == 1.0f);
 
     // Test edges and midpoint
-    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 2.0f) == 0.0f);
-    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 4.0f) == 0.5f);
-    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 6.0f, 6.0f) == 1.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 2.0f, 6.0f) == 0.0f);
+    GBL_TEST_VERIFY(shz::smoothstepf(4.0f, 2.0f, 6.0f) == 0.5f);
+    GBL_TEST_VERIFY(shz::smoothstepf(6.0f, 2.0f, 6.0f) == 1.0f);
 
     // Ensure monotonic
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.25f) < shz::smoothstepf(0.0f, 1.0f, 0.5f));
-    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 1.0f, 0.5f)  < shz::smoothstepf(0.0f, 1.0f, 0.75f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.25f, 0.0f, 1.0f) < shz::smoothstepf(0.5f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.5f, 0.0f, 1.0f) < shz::smoothstepf(0.75f, 0.0f, 1.0f));
 
     // Mirrored monotonic
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.25f) > shz::smoothstepf(1.0f, 0.0f, 0.5f));
-    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 0.5f)  > shz::smoothstepf(1.0f, 0.0f, 0.75f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.25f, 1.0f, 0.0f) > shz::smoothstepf(0.5f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.5f, 1.0f, 0.0f) > shz::smoothstepf(0.75f, 1.0f, 0.0f));
 GBL_TEST_CASE_END
 
 GBL_TEST_REGISTER(min,

--- a/test/shz_vector_test_suite.cpp
+++ b/test/shz_vector_test_suite.cpp
@@ -602,167 +602,180 @@ GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec2Step)
     // Edge == 0, scalar version
-    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(0.0f, 1.0f)) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(-0.001f, 0.001f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-1.0f, 0.0f), 0.0f) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 1.0f), 0.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-0.001f, 0.001f), 0.0f) == shz::vec2(0.0f, 1.0f));
 
     // Edge == 1, scalar version
-    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(0.0f, 1.0f)) == shz::vec2(0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(0.999f,1.001f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 1.0f), 1.0f) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.0f, 2.0f), 1.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.999f,1.001f), 1.0f) == shz::vec2(0.0f, 1.0f));
 
     // Edges for vector version, per component
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 0.0f), shz::vec2(-1.0f, 1.0f)) == shz::vec2(0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 1.0f), shz::vec2(0.0f, 0.0f)) == shz::vec2(1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.0f, 0.0f), shz::vec2(0.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-1.0f, 1.0f), shz::vec2(0.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 0.0f), shz::vec2(0.0f, 1.0f)) == shz::vec2(1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 0.0f), shz::vec2(1.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
 
     // Vector with mixed signs
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.0f, 1.0f), shz::vec2(2.0f, -2.0f)) == shz::vec2(1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(2.0f, -2.0f), shz::vec2(1.0f, 1.0f)) == shz::vec2(1.0f, 0.0f));
     GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-2.0f, 2.0f), shz::vec2(-2.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-2.0f, 2.0f), shz::vec2(-3.0f, 3.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-3.0f, 3.0f), shz::vec2(-2.0f, 2.0f)) == shz::vec2(0.0f, 1.0f));
 
     // Vector verison with fractional values
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 0.5f), shz::vec2(0.49f, 0.50f)) == shz::vec2(0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 0.5f), shz::vec2(0.50f, 0.51f)) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 1.5f), shz::vec2(1.5f, 0.5f)) == shz::vec2(1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.49f, 0.50f), shz::vec2(0.5f, 0.5f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.50f, 0.51f), shz::vec2(0.5f, 0.5f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.5f, 0.5f), shz::vec2(0.5f, 1.5f)) == shz::vec2(1.0f, 0.0f));
 
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec3Step)
     // Edge == 0, scalar version
-    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(-1.0f, 0.0f, 1.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(0.0f, 1.0f, -1.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(-0.001f, 0.001f, 0.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-1.0f, 0.0f, 1.0f), 0.0f) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 1.0f, -1.0f), 0.0f) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-0.001f, 0.001f, 0.0f), 0.0f) == shz::vec3(0.0f, 1.0f, 1.0f));
 
     // Edge == 1, scalar version
-    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(0.0f, 1.0f, 2.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(1.0f, 2.0f, 0.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(0.999f, 1.001f, 1.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 1.0f, 2.0f), 1.0f) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.0f, 2.0f, 0.0f), 1.0f) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.999f, 1.001f, 1.0f), 1.0f) == shz::vec3(0.0f, 1.0f, 1.0f));
 
     // Edges for vector version, per component
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 0.0f, 0.0f), shz::vec3(-1.0f, 1.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 1.0f, 0.0f), shz::vec3(0.0f, 0.0f, 1.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.0f, 0.0f, 1.0f), shz::vec3(0.0f, 0.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-1.0f, 1.0f, 0.0f), shz::vec3(0.0f, 0.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 0.0f, 1.0f), shz::vec3(0.0f, 1.0f, 0.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 0.0f, 0.0f), shz::vec3(1.0f, 0.0f, 1.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
 
     // Vector with mixed signs
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.0f, 1.0f, 1.0f), shz::vec3(2.0f, -2.0f, 1.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(2.0f, -2.0f, 1.0f), shz::vec3(1.0f, 1.0f, 1.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
     GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-2.0f, 2.0f, 0.0f), shz::vec3(-2.0f, 2.0f, 0.0f)) == shz::vec3(1.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-2.0f, 2.0f, 0.0f), shz::vec3(-3.0f, 3.0f, -1.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-3.0f, 3.0f, -1.0f), shz::vec3(-2.0f, 2.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
 
     // Vector version with fractional values
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 0.5f, 0.5f), shz::vec3(0.49f, 0.50f, 0.51f)) == shz::vec3(0.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 0.5f, 0.5f), shz::vec3(0.50f, 0.51f, 0.49f)) == shz::vec3(1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 1.5f, 0.5f), shz::vec3(1.5f, 0.5f, 0.5f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.49f, 0.50f, 0.51f), shz::vec3(0.5f, 0.5f, 0.5f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.50f, 0.51f, 0.49f), shz::vec3(0.5f, 0.5f, 0.5f)) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.5f, 0.5f, 0.5f), shz::vec3(0.5f, 1.5f, 0.5f)) == shz::vec3(1.0f, 0.0f, 1.0f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec4Step)
     // Edge == 0, scalar version
-    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(-1.0f, 0.0f, 1.0f, -0.001f)) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(0.0f, 1.0f, -1.0f, 0.001f)) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(-0.001f, 0.001f, 0.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-1.0f, 0.0f, 1.0f, -0.001f), 0.0f) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 1.0f, -1.0f, 0.001f), 0.0f) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-0.001f, 0.001f, 0.0f, 0.0f), 0.0f) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
 
     // Edge == 1, scalar version
-    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(0.0f, 1.0f, 2.0f, 0.999f)) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(1.0f, 2.0f, 0.0f, 1.001f)) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(0.999f, 1.001f, 1.0f, 2.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 1.0f, 2.0f, 0.999f), 1.0f) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.0f, 2.0f, 0.0f, 1.001f), 1.0f) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.999f, 1.001f, 1.0f, 2.0f), 1.0f) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
 
     // Edges for vector version, per component
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 0.0f, 0.0f, 0.0f), shz::vec4(-1.0f, 1.0f, 0.0f, 2.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 1.0f, 0.0f, 1.0f), shz::vec4( 0.0f, 0.0f, 1.0f, 1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.0f, 0.0f, 1.0f, 0.0f), shz::vec4( 0.0f, 0.0f, 0.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-1.0f, 1.0f, 0.0f, 2.0f), shz::vec4(0.0f, 0.0f, 0.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4( 0.0f, 0.0f, 1.0f, 1.0f), shz::vec4(0.0f, 1.0f, 0.0f, 1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4( 0.0f, 0.0f, 0.0f, 0.0f), shz::vec4(1.0f, 0.0f, 1.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
 
     // Vector with mixed signs
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.0f, 1.0f, 1.0f, 1.0f), shz::vec4(2.0f, -2.0f, 1.0f, -1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(2.0f, -2.0f, 1.0f, -1.0f), shz::vec4(1.0f, 1.0f, 1.0f, 1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 0.0f));
     GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f), shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f)) == shz::vec4(1.0f, 1.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f), shz::vec4(-3.0f, 3.0f, -1.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-3.0f, 3.0f, -1.0f, 0.0f), shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
 
     // Vector version with fractional values
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), shz::vec4(0.49f, 0.50f, 0.51f, 0.50f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), shz::vec4(0.50f, 0.51f, 0.49f, 0.49f)) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 1.5f, 0.5f, 1.5f), shz::vec4(1.5f, 0.5f, 0.5f, 1.5f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.49f, 0.50f, 0.51f, 0.50f), shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.50f, 0.51f, 0.49f, 0.49f), shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.5f, 0.5f, 0.5f, 1.5f), shz::vec4(0.5f, 1.5f, 0.5f, 1.5f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec2Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(-1.0f, 0.0f), 0.0f, 1.0f) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.0f, 2.0f), 0.0f, 1.0f) == shz::vec2(1.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.25f)) == shz::vec2(0.5f, 0.15625f));   // 1/2, 5/32
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.75f, 0.5f))  == shz::vec2(0.84375f, 0.5f));    // 27/32, 1/2
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.25f), 0.0f, 1.0f) == shz::vec2(0.5f, 0.15625f));   // 1/2, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.75f, 0.5f), 0.0f, 1.0f)  == shz::vec2(0.84375f, 0.5f));    // 27/32, 1/2
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.25f, 0.75f)) == shz::vec2(0.84375f, 0.15625f)); // 27/32, 5/32
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f))  == shz::vec2(0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(-1.0f, 0.0f), 1.0f, 0.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.0f, 2.0f),  1.0f, 0.0f) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.75f), 1.0f, 0.0f) == shz::vec2(0.84375f, 0.15625f)); // 27/32, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f)  == shz::vec2(0.5f, 0.5f));
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(2.0f, 6.0f, shz::vec2(2.0f, 4.0f)) == shz::vec2(0.0f, 0.5f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(2.0f, 6.0f, shz::vec2(6.0f, 8.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(2.0f, 4.0f), 2.0f, 6.0f) == shz::vec2(0.0f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(6.0f, 8.0f), 2.0f, 6.0f) == shz::vec2(1.0f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.25f, 0.25f)).x < shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.5f)).y  < shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.75f, 0.75f)).y);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec2::smoothstep(shz::vec2(0.75f, 0.75f), 0.0f, 1.0f).y);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.25f, 0.25f)).x > shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f)).y  > shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.75f, 0.75f)).y);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).y  > shz::vec2::smoothstep(shz::vec2(0.75f, 0.75f), 1.0f, 0.0f).y);
+
+    // Per component test
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.5f, 0.5f), shz::vec2(1.0f, 0.0f), shz::vec2(2.0f, 1.0f)) == shz::vec2(0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec2(0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec2(0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec3Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(-1.0f, 0.0f, 2.0f)) == shz::vec3(0.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(-1.0f, 0.0f, 2.0f), 0.0f, 1.0f) == shz::vec3(0.0f, 0.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.25f, 0.5f, 0.75f)) == shz::vec3(0.15625f, 0.5f, 0.84375f)); // 5/32, 1/2, 27/32
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.5f, 0.75f), 0.0f, 1.0f) == shz::vec3(0.15625f, 0.5f, 0.84375f)); // 5/32, 1/2, 27/32
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(-1.0f, 0.0f, 2.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.25f, 0.5f, 0.75f)) == shz::vec3(0.84375f, 0.5f, 0.15625f)); // 27/32, 1/2, 5/32
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(-1.0f, 0.0f, 2.0f), 1.0f, 0.0f) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.5f, 0.75f), 1.0f, 0.0f) == shz::vec3(0.84375f, 0.5f, 0.15625f)); // 27/32, 1/2, 5/32
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(2.0f, 6.0f, shz::vec3(2.0f, 4.0f, 6.0f)) == shz::vec3(0.0f, 0.5f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(2.0f, 4.0f, 6.0f), 2.0f, 6.0f) == shz::vec3(0.0f, 0.5f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.25f, 0.25f, 0.25f)).x < shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.5f, 0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.5f, 0.5f, 0.5f)).y  < shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.75f, 0.75f, 0.75f)).y);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec3::smoothstep(shz::vec3(0.75f, 0.75f, 0.75f), 0.0f, 1.0f).y);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.25f, 0.25f, 0.25f)).x > shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.5f, 0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.5f, 0.5f, 0.5f)).z  > shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.75f, 0.75f, 0.75f)).z);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).z  > shz::vec3::smoothstep(shz::vec3(0.75f, 0.75f, 0.75f), 1.0f, 0.0f).z);
+
+    // Per component test
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(1.5f, 0.5f, 3.0f),
+                                          shz::vec3(1.0f, 0.0f, 2.0f),
+                                          shz::vec3(2.0f, 1.0f, 4.0f)) == shz::vec3(0.5f, 0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec3(0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec3(0.5f, 0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec4Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f)) == shz::vec4(0.0f, 0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 0.0f, 1.0f) == shz::vec4(0.0f, 0.0f, 1.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.25f, 0.5f, 0.75f, 0.0f)) == shz::vec4(0.15625f, 0.5f, 0.84375f, 0.0f)); // 5/32, 1/2, 27/32, 0
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.5f, 0.75f, 0.0f), 0.0f, 1.0f) == shz::vec4(0.15625f, 0.5f, 0.84375f, 0.0f)); // 5/32, 1/2, 27/32, 0
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f)) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.25f, 0.5f, 0.75f, 0.5f)) == shz::vec4(0.84375f, 0.5f, 0.15625f, 0.5f)); // 27/32, 1/2, 5/32, 1/2
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 1.0f, 0.0f) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.5f, 0.75f, 0.5f), 1.0f, 0.0f) == shz::vec4(0.84375f, 0.5f, 0.15625f, 0.5f)); // 27/32, 1/2, 5/32, 1/2
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(2.0f, 6.0f, shz::vec4(2.0f, 4.0f, 6.0f, 8.0f)) == shz::vec4(0.0f, 0.5f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(2.0f, 4.0f, 6.0f, 8.0f), 2.0f, 6.0f) == shz::vec4(0.0f, 0.5f, 1.0f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.25f, 0.25f, 0.25f, 0.25f)).x < shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).w  < shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.75f, 0.75f, 0.75f, 0.75f)).w);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).w  < shz::vec4::smoothstep(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 0.0f, 1.0f).w);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.25f, 0.25f, 0.25f, 0.25f)).x > shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).x);
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).w  > shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.75f, 0.75f, 0.75f, 0.75f)).w);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).w  > shz::vec4::smoothstep(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 1.0f, 0.0f).w);
+
+    // Per component test
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(1.5f, 0.5f, 3.0f, 0.25f),
+                                          shz::vec4(1.0f, 0.0f, 2.0f, 0.0f),
+                                          shz::vec4(2.0f, 1.0f, 4.0f, 0.5f)) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_REGISTER(vec2Construct,

--- a/test/shz_vector_test_suite.cpp
+++ b/test/shz_vector_test_suite.cpp
@@ -600,6 +600,171 @@ GBL_TEST_CASE(vec3CubicHermite)
     GBL_TEST_VERIFY(test(m0, p0, m1, p1, 0.3f));
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(vec2Step)
+    // Edge == 0, scalar version
+    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(0.0f, 1.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(0.0f, shz::vec2(-0.001f, 0.001f)) == shz::vec2(0.0f, 1.0f));
+
+    // Edge == 1, scalar version
+    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(0.0f, 1.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(1.0f, shz::vec2(0.999f,1.001f)) == shz::vec2(0.0f, 1.0f));
+
+    // Edges for vector version, per component
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 0.0f), shz::vec2(-1.0f, 1.0f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.0f, 1.0f), shz::vec2(0.0f, 0.0f)) == shz::vec2(1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.0f, 0.0f), shz::vec2(0.0f, 0.0f)) == shz::vec2(0.0f, 1.0f));
+
+    // Vector with mixed signs
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(1.0f, 1.0f), shz::vec2(2.0f, -2.0f)) == shz::vec2(1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-2.0f, 2.0f), shz::vec2(-2.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(-2.0f, 2.0f), shz::vec2(-3.0f, 3.0f)) == shz::vec2(0.0f, 1.0f));
+
+    // Vector verison with fractional values
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 0.5f), shz::vec2(0.49f, 0.50f)) == shz::vec2(0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 0.5f), shz::vec2(0.50f, 0.51f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::step(shz::vec2(0.5f, 1.5f), shz::vec2(1.5f, 0.5f)) == shz::vec2(1.0f, 0.0f));
+
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(vec3Step)
+    // Edge == 0, scalar version
+    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(-1.0f, 0.0f, 1.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(0.0f, 1.0f, -1.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(0.0f, shz::vec3(-0.001f, 0.001f, 0.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+
+    // Edge == 1, scalar version
+    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(0.0f, 1.0f, 2.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(1.0f, 2.0f, 0.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(1.0f, shz::vec3(0.999f, 1.001f, 1.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+
+    // Edges for vector version, per component
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 0.0f, 0.0f), shz::vec3(-1.0f, 1.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.0f, 1.0f, 0.0f), shz::vec3(0.0f, 0.0f, 1.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.0f, 0.0f, 1.0f), shz::vec3(0.0f, 0.0f, 0.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
+
+    // Vector with mixed signs
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(1.0f, 1.0f, 1.0f), shz::vec3(2.0f, -2.0f, 1.0f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-2.0f, 2.0f, 0.0f), shz::vec3(-2.0f, 2.0f, 0.0f)) == shz::vec3(1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(-2.0f, 2.0f, 0.0f), shz::vec3(-3.0f, 3.0f, -1.0f)) == shz::vec3(0.0f, 1.0f, 0.0f));
+
+    // Vector version with fractional values
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 0.5f, 0.5f), shz::vec3(0.49f, 0.50f, 0.51f)) == shz::vec3(0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 0.5f, 0.5f), shz::vec3(0.50f, 0.51f, 0.49f)) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::step(shz::vec3(0.5f, 1.5f, 0.5f), shz::vec3(1.5f, 0.5f, 0.5f)) == shz::vec3(1.0f, 0.0f, 1.0f));
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(vec4Step)
+    // Edge == 0, scalar version
+    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(-1.0f, 0.0f, 1.0f, -0.001f)) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(0.0f, 1.0f, -1.0f, 0.001f)) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(0.0f, shz::vec4(-0.001f, 0.001f, 0.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+
+    // Edge == 1, scalar version
+    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(0.0f, 1.0f, 2.0f, 0.999f)) == shz::vec4(0.0f, 1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(1.0f, 2.0f, 0.0f, 1.001f)) == shz::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(1.0f, shz::vec4(0.999f, 1.001f, 1.0f, 2.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+
+    // Edges for vector version, per component
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 0.0f, 0.0f, 0.0f), shz::vec4(-1.0f, 1.0f, 0.0f, 2.0f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.0f, 1.0f, 0.0f, 1.0f), shz::vec4( 0.0f, 0.0f, 1.0f, 1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.0f, 0.0f, 1.0f, 0.0f), shz::vec4( 0.0f, 0.0f, 0.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
+
+    // Vector with mixed signs
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(1.0f, 1.0f, 1.0f, 1.0f), shz::vec4(2.0f, -2.0f, 1.0f, -1.0f)) == shz::vec4(1.0f, 0.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f), shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f)) == shz::vec4(1.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(-2.0f, 2.0f, 0.0f, -1.0f), shz::vec4(-3.0f, 3.0f, -1.0f, 0.0f)) == shz::vec4(0.0f, 1.0f, 0.0f, 1.0f));
+
+    // Vector version with fractional values
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), shz::vec4(0.49f, 0.50f, 0.51f, 0.50f)) == shz::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), shz::vec4(0.50f, 0.51f, 0.49f, 0.49f)) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::step(shz::vec4(0.5f, 1.5f, 0.5f, 1.5f), shz::vec4(1.5f, 0.5f, 0.5f, 1.5f)) == shz::vec4(1.0f, 0.0f, 1.0f, 1.0f));
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(vec2Smoothstep)
+    // Edge == (0,1), scalar-edge overload, per-component clamping
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(1.0f, 1.0f));
+
+    // Edge == (0,1), exact values
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.25f)) == shz::vec2(0.5f, 0.15625f));   // 1/2, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.75f, 0.5f))  == shz::vec2(0.84375f, 0.5f));    // 27/32, 1/2
+
+    // Reversed edges (undefined in spec)
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(-1.0f, 0.0f)) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(1.0f, 2.0f)) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.25f, 0.75f)) == shz::vec2(0.84375f, 0.15625f)); // 27/32, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f))  == shz::vec2(0.5f, 0.5f));
+
+    // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(2.0f, 6.0f, shz::vec2(2.0f, 4.0f)) == shz::vec2(0.0f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(2.0f, 6.0f, shz::vec2(6.0f, 8.0f)) == shz::vec2(1.0f, 1.0f));
+
+    // Ensure monotonic per component (forward edges)
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.25f, 0.25f)).x < shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.5f, 0.5f)).y  < shz::vec2::smoothstep(0.0f, 1.0f, shz::vec2(0.75f, 0.75f)).y);
+
+    // Mirrored monotonic per component (reversed edges)
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.25f, 0.25f)).x > shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.5f, 0.5f)).y  > shz::vec2::smoothstep(1.0f, 0.0f, shz::vec2(0.75f, 0.75f)).y);
+
+    // Conversion case, sideffect of vector constructor
+    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec2(0.5f, 0.5f));
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(vec3Smoothstep)
+    // Edge == (0,1), scalar-edge overload, per-component clamping
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(-1.0f, 0.0f, 2.0f)) == shz::vec3(0.0f, 0.0f, 1.0f));
+
+    // Edge == (0,1), exact values
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.25f, 0.5f, 0.75f)) == shz::vec3(0.15625f, 0.5f, 0.84375f)); // 5/32, 1/2, 27/32
+
+    // Reversed edges (undefined in spec)
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(-1.0f, 0.0f, 2.0f)) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.25f, 0.5f, 0.75f)) == shz::vec3(0.84375f, 0.5f, 0.15625f)); // 27/32, 1/2, 5/32
+
+    // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(2.0f, 6.0f, shz::vec3(2.0f, 4.0f, 6.0f)) == shz::vec3(0.0f, 0.5f, 1.0f));
+
+    // Ensure monotonic per component (forward edges)
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.25f, 0.25f, 0.25f)).x < shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.5f, 0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.5f, 0.5f, 0.5f)).y  < shz::vec3::smoothstep(0.0f, 1.0f, shz::vec3(0.75f, 0.75f, 0.75f)).y);
+
+    // Mirrored monotonic per component (reversed edges)
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.25f, 0.25f, 0.25f)).x > shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.5f, 0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.5f, 0.5f, 0.5f)).z  > shz::vec3::smoothstep(1.0f, 0.0f, shz::vec3(0.75f, 0.75f, 0.75f)).z);
+
+    // Conversion case, sideffect of vector constructor
+    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec3(0.5f, 0.5f, 0.5f));
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(vec4Smoothstep)
+    // Edge == (0,1), scalar-edge overload, per-component clamping
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f)) == shz::vec4(0.0f, 0.0f, 1.0f, 1.0f));
+
+    // Edge == (0,1), exact values
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.25f, 0.5f, 0.75f, 0.0f)) == shz::vec4(0.15625f, 0.5f, 0.84375f, 0.0f)); // 5/32, 1/2, 27/32, 0
+
+    // Reversed edges (undefined in spec)
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f)) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.25f, 0.5f, 0.75f, 0.5f)) == shz::vec4(0.84375f, 0.5f, 0.15625f, 0.5f)); // 27/32, 1/2, 5/32, 1/2
+
+    // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(2.0f, 6.0f, shz::vec4(2.0f, 4.0f, 6.0f, 8.0f)) == shz::vec4(0.0f, 0.5f, 1.0f, 1.0f));
+
+    // Ensure monotonic per component (forward edges)
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.25f, 0.25f, 0.25f, 0.25f)).x < shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).w  < shz::vec4::smoothstep(0.0f, 1.0f, shz::vec4(0.75f, 0.75f, 0.75f, 0.75f)).w);
+
+    // Mirrored monotonic per component (reversed edges)
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.25f, 0.25f, 0.25f, 0.25f)).x > shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.5f, 0.5f, 0.5f, 0.5f)).w  > shz::vec4::smoothstep(1.0f, 0.0f, shz::vec4(0.75f, 0.75f, 0.75f, 0.75f)).w);
+
+    // Conversion case, sideffect of vector constructor
+    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.0f, 1.0f, 0.5f) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
+GBL_TEST_CASE_END
+
 GBL_TEST_REGISTER(vec2Construct,
                   vec2Set,
                   vec2Lerp,
@@ -629,4 +794,10 @@ GBL_TEST_REGISTER(vec2Construct,
                   vec2Move,
                   vec3Move,
                   vec4Move,
-                  vec3CubicHermite)
+                  vec3CubicHermite,
+                  vec2Step,
+                  vec3Step,
+                  vec4Step,
+                  vec2Smoothstep,
+                  vec3Smoothstep,
+                  vec4Smoothstep)

--- a/test/shz_vector_test_suite.cpp
+++ b/test/shz_vector_test_suite.cpp
@@ -684,98 +684,100 @@ GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec2Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(-1.0f, 0.0f), 0.0f, 1.0f) == shz::vec2(0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.0f, 2.0f), 0.0f, 1.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(-1.0f, 0.0f), 0.0f, 1.0f) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(1.0f, 2.0f), 0.0f, 1.0f) == shz::vec2(1.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.25f), 0.0f, 1.0f) == shz::vec2(0.5f, 0.15625f));   // 1/2, 5/32
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.75f, 0.5f), 0.0f, 1.0f)  == shz::vec2(0.84375f, 0.5f));    // 27/32, 1/2
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.25f), 0.0f, 1.0f) == shz::vec2(0.5f, 0.15625f));   // 1/2, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.75f, 0.5f), 0.0f, 1.0f)  == shz::vec2(0.84375f, 0.5f));    // 27/32, 1/2
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(-1.0f, 0.0f), 1.0f, 0.0f) == shz::vec2(1.0f, 1.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.0f, 2.0f),  1.0f, 0.0f) == shz::vec2(0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.75f), 1.0f, 0.0f) == shz::vec2(0.84375f, 0.15625f)); // 27/32, 5/32
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f)  == shz::vec2(0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(-1.0f, 0.0f), 1.0f, 0.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(1.0f, 2.0f),  1.0f, 0.0f) == shz::vec2(0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.25f, 0.75f), 1.0f, 0.0f) == shz::vec2(0.84375f, 0.15625f)); // 27/32, 5/32
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f)  == shz::vec2(0.5f, 0.5f));
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(2.0f, 4.0f), 2.0f, 6.0f) == shz::vec2(0.0f, 0.5f));
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(6.0f, 8.0f), 2.0f, 6.0f) == shz::vec2(1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(2.0f, 4.0f), 2.0f, 6.0f) == shz::vec2(0.0f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(6.0f, 8.0f), 2.0f, 6.0f) == shz::vec2(1.0f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).x);
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec2::smoothstep(shz::vec2(0.75f, 0.75f), 0.0f, 1.0f).y);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec2::smoothstep_safe(shz::vec2(0.75f, 0.75f), 0.0f, 1.0f).y);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).x);
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).y  > shz::vec2::smoothstep(shz::vec2(0.75f, 0.75f), 1.0f, 0.0f).y);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(0.5f, 0.5f), 1.0f, 0.0f).y  > shz::vec2::smoothstep_safe(shz::vec2(0.75f, 0.75f), 1.0f, 0.0f).y);
 
     // Per component test
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(shz::vec2(1.5f, 0.5f), shz::vec2(1.0f, 0.0f), shz::vec2(2.0f, 1.0f)) == shz::vec2(0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(shz::vec2(1.5f, 0.5f), 
+                                               shz::vec2(1.0f, 0.0f), 
+                                               shz::vec2(2.0f, 1.0f)) == shz::vec2(0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec2::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec2(0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec2::smoothstep_safe(0.5f, 0.0f, 1.0f) == shz::vec2(0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec3Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(-1.0f, 0.0f, 2.0f), 0.0f, 1.0f) == shz::vec3(0.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(-1.0f, 0.0f, 2.0f), 0.0f, 1.0f) == shz::vec3(0.0f, 0.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.5f, 0.75f), 0.0f, 1.0f) == shz::vec3(0.15625f, 0.5f, 0.84375f)); // 5/32, 1/2, 27/32
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.25f, 0.5f, 0.75f), 0.0f, 1.0f) == shz::vec3(0.15625f, 0.5f, 0.84375f)); // 5/32, 1/2, 27/32
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(-1.0f, 0.0f, 2.0f), 1.0f, 0.0f) == shz::vec3(1.0f, 1.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.5f, 0.75f), 1.0f, 0.0f) == shz::vec3(0.84375f, 0.5f, 0.15625f)); // 27/32, 1/2, 5/32
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(-1.0f, 0.0f, 2.0f), 1.0f, 0.0f) == shz::vec3(1.0f, 1.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.25f, 0.5f, 0.75f), 1.0f, 0.0f) == shz::vec3(0.84375f, 0.5f, 0.15625f)); // 27/32, 1/2, 5/32
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(2.0f, 4.0f, 6.0f), 2.0f, 6.0f) == shz::vec3(0.0f, 0.5f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(2.0f, 4.0f, 6.0f), 2.0f, 6.0f) == shz::vec3(0.0f, 0.5f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec3::smoothstep(shz::vec3(0.75f, 0.75f, 0.75f), 0.0f, 1.0f).y);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec3::smoothstep_safe(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.5f, 0.5f, 0.5f), 0.0f, 1.0f).y  < shz::vec3::smoothstep_safe(shz::vec3(0.75f, 0.75f, 0.75f), 0.0f, 1.0f).y);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).z  > shz::vec3::smoothstep(shz::vec3(0.75f, 0.75f, 0.75f), 1.0f, 0.0f).z);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec3::smoothstep_safe(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(0.5f, 0.5f, 0.5f), 1.0f, 0.0f).z  > shz::vec3::smoothstep_safe(shz::vec3(0.75f, 0.75f, 0.75f), 1.0f, 0.0f).z);
 
     // Per component test
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(shz::vec3(1.5f, 0.5f, 3.0f),
-                                          shz::vec3(1.0f, 0.0f, 2.0f),
-                                          shz::vec3(2.0f, 1.0f, 4.0f)) == shz::vec3(0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(shz::vec3(1.5f, 0.5f, 3.0f),
+                                               shz::vec3(1.0f, 0.0f, 2.0f),
+                                               shz::vec3(2.0f, 1.0f, 4.0f)) == shz::vec3(0.5f, 0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec3::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec3(0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec3::smoothstep_safe(0.5f, 0.0f, 1.0f) == shz::vec3(0.5f, 0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(vec4Smoothstep)
     // Edge == (0,1), scalar-edge overload, per-component clamping
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 0.0f, 1.0f) == shz::vec4(0.0f, 0.0f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 0.0f, 1.0f) == shz::vec4(0.0f, 0.0f, 1.0f, 1.0f));
 
     // Edge == (0,1), exact values
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.5f, 0.75f, 0.0f), 0.0f, 1.0f) == shz::vec4(0.15625f, 0.5f, 0.84375f, 0.0f)); // 5/32, 1/2, 27/32, 0
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.25f, 0.5f, 0.75f, 0.0f), 0.0f, 1.0f) == shz::vec4(0.15625f, 0.5f, 0.84375f, 0.0f)); // 5/32, 1/2, 27/32, 0
 
     // Reversed edges (undefined in spec)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 1.0f, 0.0f) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.5f, 0.75f, 0.5f), 1.0f, 0.0f) == shz::vec4(0.84375f, 0.5f, 0.15625f, 0.5f)); // 27/32, 1/2, 5/32, 1/2
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(-1.0f, 0.0f, 1.0f, 2.0f), 1.0f, 0.0f) == shz::vec4(1.0f, 1.0f, 0.0f, 0.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.25f, 0.5f, 0.75f, 0.5f), 1.0f, 0.0f) == shz::vec4(0.84375f, 0.5f, 0.15625f, 0.5f)); // 27/32, 1/2, 5/32, 1/2
 
     // Different edges, test edges and midpoint (2..6 => midpoint at 4 gives 0.5)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(2.0f, 4.0f, 6.0f, 8.0f), 2.0f, 6.0f) == shz::vec4(0.0f, 0.5f, 1.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(2.0f, 4.0f, 6.0f, 8.0f), 2.0f, 6.0f) == shz::vec4(0.0f, 0.5f, 1.0f, 1.0f));
 
     // Ensure monotonic per component (forward edges)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).w  < shz::vec4::smoothstep(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 0.0f, 1.0f).w);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 0.0f, 1.0f).x < shz::vec4::smoothstep_safe(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 0.0f, 1.0f).w  < shz::vec4::smoothstep_safe(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 0.0f, 1.0f).w);
 
     // Mirrored monotonic per component (reversed edges)
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).w  > shz::vec4::smoothstep(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 1.0f, 0.0f).w);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.25f, 0.25f, 0.25f, 0.25f), 1.0f, 0.0f).x > shz::vec4::smoothstep_safe(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).x);
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(0.5f, 0.5f, 0.5f, 0.5f), 1.0f, 0.0f).w  > shz::vec4::smoothstep_safe(shz::vec4(0.75f, 0.75f, 0.75f, 0.75f), 1.0f, 0.0f).w);
 
     // Per component test
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(shz::vec4(1.5f, 0.5f, 3.0f, 0.25f),
-                                          shz::vec4(1.0f, 0.0f, 2.0f, 0.0f),
-                                          shz::vec4(2.0f, 1.0f, 4.0f, 0.5f)) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(shz::vec4(1.5f, 0.5f, 3.0f, 0.25f),
+                                               shz::vec4(1.0f, 0.0f, 2.0f, 0.0f),
+                                               shz::vec4(2.0f, 1.0f, 4.0f, 0.5f)) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
 
     // Conversion case, sideffect of vector constructor
-    GBL_TEST_VERIFY(shz::vec4::smoothstep(0.5f, 0.0f, 1.0f) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
+    GBL_TEST_VERIFY(shz::vec4::smoothstep_safe(0.5f, 0.0f, 1.0f) == shz::vec4(0.5f, 0.5f, 0.5f, 0.5f));
 GBL_TEST_CASE_END
 
 GBL_TEST_REGISTER(vec2Construct,


### PR DESCRIPTION
Adds step and smoothstep plus all the per-component vector and broadcast versions.

I've done the version that is most compatible with glm/cglm. Was thinking of renaming this one as something like '_safe' and replace these with the fsrra version.

Just want to be sure I've actually structured this all correct first though before I go wild. The C++ template is looking like some psychotic manual overload.