### PR TITLE
Smoothstep fixes and consistency tests

### DIFF
--- a/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
+++ b/include/sh4zam/inline/sw/shz_scalar_sw.inl.h
@@ -316,9 +316,6 @@ SHZ_FORCE_INLINE float shz_stepf_sw(float x, float edge) SHZ_NOEXCEPT {
 SHZ_FORCE_INLINE float shz_smoothstepf_sw(float x, float edge0, float edge1) SHZ_NOEXCEPT {
     if (x >= edge1) return 1.0f;
     if (x <= edge0) return 0.0f;
-    if (edge0 == edge1) {
-        return shz_stepf(x, edge0);
-    }
 
     float diff = edge1 - edge0;
 

--- a/test/shz_scalar_test_suite.cpp
+++ b/test/shz_scalar_test_suite.cpp
@@ -292,6 +292,12 @@ GBL_TEST_CASE(smoothstepf)
     // Ensure monotonic
     GBL_TEST_VERIFY(shz::smoothstepf(0.25f, 0.0f, 1.0f) < shz::smoothstepf(0.5f, 0.0f, 1.0f));
     GBL_TEST_VERIFY(shz::smoothstepf(0.5f, 0.0f, 1.0f) < shz::smoothstepf(0.75f, 0.0f, 1.0f));
+
+    // Ensure edge behavior matches safe variants.
+    GBL_TEST_VERIFY(shz::smoothstepf(-1.0f, 0.0f, 1.0f) == shz::smoothstepf_safe(-1.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::smoothstepf(2.0f, 0.0f, 1.0f) == shz::smoothstepf_safe(2.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::smoothstepf(0.0f, 0.0f, 1.0f) == shz::smoothstepf_safe(0.0f, 0.0f, 1.0f));
+    GBL_TEST_VERIFY(shz::smoothstepf(1.0f, 0.0f, 1.0f) == shz::smoothstepf_safe(1.0f, 0.0f, 1.0f));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(smoothstepf_safe)


### PR DESCRIPTION
Remove redundant check. Must have left it over before I added the two branches above it. Oops.

gcc appears to be smart enough to nuke it.

Added unit test to ensure consistency between the two smoothstep functions at the edges.