### PR TITLE
shz_xmtrx_init_screen potential fix and unit tests

### DIFF
--- a/include/sh4zam/inline/shz_xmtrx.inl.h
+++ b/include/sh4zam/inline/shz_xmtrx.inl.h
@@ -2705,9 +2705,9 @@ SHZ_INLINE void shz_xmtrx_init_screen(float width, float height) SHZ_NOEXCEPT {
     asm volatile(R"(
         frchg
         fldi0   fr1
-        fmov.s  @r5, fr13
+        fmov.s  @%[h], fr13
         fmul    fr1, fr2
-        fmov.s  @r4, fr0
+        fmov.s  @%[w], fr0
         fmul    fr1, fr3
         fldi1   fr15
         fmul    fr1, fr4
@@ -2725,7 +2725,9 @@ SHZ_INLINE void shz_xmtrx_init_screen(float width, float height) SHZ_NOEXCEPT {
     )"
     :
     : [w] "r" (&width), [h] "r" (&height),
-      "m" (width), "m" (height));
+      "m" (width), "m" (height)
+    : "fr0", "fr1", "fr2", "fr3", "fr4", "fr5", "fr6", "fr7",
+      "fr8", "fr9", "fr10", "fr11", "fr12", "fr13", "fr14", "fr15");
 }
 
 // ****************************************************************

--- a/include/sh4zam/inline/shz_xmtrx.inl.h
+++ b/include/sh4zam/inline/shz_xmtrx.inl.h
@@ -2698,6 +2698,16 @@ SHZ_INLINE void shz_xmtrx_apply_perspective(float fov, float aspect, float near_
     : "fpul", "fr7", "fr8", "fr9", "fr10", "fr11");
 }
 
+// ****************************************************************
+// shz_xmtrx_init_screen(float w, float h)
+// ****************************************************************
+//  fr[n + 0] | fr[n + 4] | fr[n + 8] | fr[n + 12]
+// -----------+-----------+-----------+-----------
+//	w*0.5f    | 0.0f      | 0.0f      | w*0.5f
+// 	0.0f      | -h*0.5f   | 0.0f      | h*0.5f
+// 	0.0f      | 0.0f      | 1.0f      | 0.0f
+//  0.0f      | 0.0f      | 0.0f      | 1.0f
+// ****************************************************************
 SHZ_INLINE void shz_xmtrx_init_screen(float width, float height) SHZ_NOEXCEPT {
     width  *= 0.5f;
     height *= 0.5f;

--- a/include/sh4zam/shz_xmtrx.hpp
+++ b/include/sh4zam/shz_xmtrx.hpp
@@ -305,7 +305,7 @@ struct xmtrx {
         shz_xmtrx_init_outer_product(a, b);
     }
 
-    //! C++ wrapper around shz_xmtx_init_screen().
+    //! C++ wrapper around shz_xmtrx_init_screen().
     SHZ_FORCE_INLINE static void init_screen(float width, float height) noexcept {
         shz_xmtrx_init_screen(width, height);
     }
@@ -450,6 +450,11 @@ struct xmtrx {
     //! C++ wrapper around shz_xmtrx_apply_symmetric_skew().
     SHZ_FORCE_INLINE static void apply_symmetric_skew(float x, float y, float z) noexcept {
         shz_xmtrx_apply_symmetric_skew(x, y, z);
+    }
+
+    //! C++ wrapper around shz_xmtrx_apply_screen().
+    SHZ_FORCE_INLINE static void apply_screen(float width, float height) noexcept {
+        shz_xmtrx_apply_screen(width, height);
     }
 
     //! C++ wrapper around shz_xmtrx_apply_permutation_wxyz().

--- a/test/shz_xmtrx_test_suite.cpp
+++ b/test/shz_xmtrx_test_suite.cpp
@@ -482,6 +482,13 @@ GBL_TEST_CASE(init_symmetric_skew)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(init_screen)
+    randomize_xmtrx_();
+    shz::xmtrx::init_screen(640.0f, 480.0f);
+    GBL_TEST_CALL(verify_matrix(GBL_SELF_TYPE_NAME,
+                { 320.0f, 0.0f,    0.0f, 320.0f,
+                 -0.0f,  -240.0f, -0.0f, 240.0f,
+                  0.0f,   0.0f,    1.0f, 0.0f,
+                  0.0f,   0.0f,    0.0f, 1.0f }));
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(init_permutation_wxyz)
@@ -722,6 +729,41 @@ GBL_TEST_CASE(apply_ortho)
     GBL_TEST_VERIFY(shzmat == cunion.shzcmat);
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(apply_screen)
+    shz::xmtrx::init_identity_safe();
+    shz::xmtrx::apply_screen(640.0f, 480.0f);
+
+    shz::mat4x4 applied_screen_mat;
+    shz::xmtrx::store(&applied_screen_mat);
+
+    // Ensure apply_screen computes
+    GBL_TEST_CALL(verify_matrix(GBL_SELF_TYPE_NAME,
+                { 320.0f, -0.0f,   0.0f, 320.0f,
+                 -0.0f,   -240.0f, 0.0f, 240.0f,
+                  0.0f,   -0.0f,   1.0f, 0.0f,
+                  0.0f,   -0.0f,   0.0f, 1.0f }));
+
+    // Check bruces balls
+    randomize_xmtrx_();
+    shz::xmtrx::init_identity();
+    shz::xmtrx::apply_permutation_wxyz();
+    shz::xmtrx::apply_screen(640.0f, 480.0f);
+    
+    GBL_TEST_CALL(verify_matrix(GBL_SELF_TYPE_NAME,
+            { 0.0f,   -0.0f,   0.0f, 1.0f,
+              320.0f,  0.0f,   0.0f, 320.0f,
+              0.0f,   -240.0f, 0.0f, 240.0f,
+              0.0f,   -0.0f,   1.0f, 0.0f }));
+
+    // Check parity with init_screen
+    randomize_xmtrx_();
+    shz::xmtrx::init_screen(640.0f, 480.0f);
+    shz::mat4x4 init_screen_mat;
+    shz::xmtrx::store(&init_screen_mat);
+
+    GBL_TEST_VERIFY(applied_screen_mat == init_screen_mat);
+GBL_TEST_CASE_END
+
 GBL_TEST_REGISTER(read_write_registers,
                   read_write_rows,
                   read_write_cols,
@@ -781,4 +823,5 @@ GBL_TEST_REGISTER(read_write_registers,
                   load_apply_store_4x4,
                   load_apply_store_unaligned_4x4,
                   translate,
-                  apply_ortho)
+                  apply_ortho,
+                  apply_screen)


### PR DESCRIPTION
Potential fix for `init_screen`. It looks like width was going into r4 and nothing into r5. I shifted them to `r3` and `r4` and got the same result as the `apply_screen` method.

Also added unit tests for both. Including a parity check between `init` and `apply`.