### PR TITLE
transform_point2 needs 1.0 for W component

### DIFF
--- a/include/sh4zam/inline/shz_xmtrx.inl.h
+++ b/include/sh4zam/inline/shz_xmtrx.inl.h
@@ -3370,7 +3370,7 @@ SHZ_FORCE_INLINE shz_vec2_t shz_xmtrx_transform_vec2(shz_vec2_t vec) SHZ_NOEXCEP
 }
 
 SHZ_FORCE_INLINE shz_vec2_t shz_xmtrx_transform_point2(shz_vec2_t pt) SHZ_NOEXCEPT {
-    return shz_xmtrx_transform_vec3(shz_vec2_vec3(pt, 1.0f)).xy;
+    return shz_xmtrx_transform_vec4(shz_vec2_vec4(pt, 0.0f, 1.0f)).xy;
 }
 
 SHZ_FORCE_INLINE shz_vec3_t shz_xmtrx_transform_point3(shz_vec3_t pt) SHZ_NOEXCEPT {


### PR DESCRIPTION
Small issue with `shz_xmtrx_transform_point2`. It puts 1.0 into Z instead of W causing translation to be dropped and act like `shz_xmtrx_transform_vec2`.

I have a few unit tests for all the transform variants but they were shit so I'll refine them and compare against cglm before submitting it.