### PR TITLE
Add ortho and frustum to C++ interface for mat4x4

### DIFF
--- a/include/sh4zam/inline/shz_matrix.inl.h
+++ b/include/sh4zam/inline/shz_matrix.inl.h
@@ -297,6 +297,18 @@ SHZ_INLINE void shz_mat4x4_apply_lookat(shz_mat4x4_t* m, shz_vec3_t pos, shz_vec
     shz_xmtrx_store_4x4(m);
 }
 
+SHZ_INLINE void shz_mat4x4_apply_ortho(shz_mat4x4_t* m, float left, float right, float bottom, float top, float znear, float zfar) SHZ_NOEXCEPT {
+    shz_xmtrx_load_4x4(m);
+    shz_xmtrx_apply_ortho(left, right, bottom, top, znear, zfar);
+    shz_xmtrx_store_4x4(m);
+}
+
+SHZ_INLINE void shz_mat4x4_apply_frustum(shz_mat4x4_t* m, float left, float right, float bottom, float top, float znear, float zfar) SHZ_NOEXCEPT {
+    shz_xmtrx_load_4x4(m);
+    shz_xmtrx_apply_frustum(left, right, bottom, top, znear, zfar);
+    shz_xmtrx_store_4x4(m);
+}
+
 SHZ_INLINE void shz_mat4x4_apply_perspective(shz_mat4x4_t* m, float fov, float aspect, float znear) SHZ_NOEXCEPT {
     shz_xmtrx_load_4x4(m);
     shz_xmtrx_apply_perspective(fov, aspect, znear);

--- a/include/sh4zam/shz_matrix.h
+++ b/include/sh4zam/shz_matrix.h
@@ -461,6 +461,18 @@ SHZ_INLINE void shz_mat4x4_apply_rotation_quat(shz_mat4x4_t* m, shz_quat_t q) SH
 */
 SHZ_INLINE void shz_mat4x4_apply_lookat(shz_mat4x4_t* m, shz_vec3_t pos, shz_vec3_t target, shz_vec3_t up) SHZ_NOEXCEPT;
 
+/*! Multiplies and accumulates the ortho matrix constructed from the given values onto the given matrix.
+
+    \warning This routine clobbers XMTRX.
+*/
+SHZ_INLINE void shz_mat4x4_apply_ortho(shz_mat4x4_t* m, float left, float right, float bottom, float top, float znear, float zfar) SHZ_NOEXCEPT;
+
+/*! Multiplies and accumulates the frustum matrix constructed from the given values onto the given matrix.
+
+    \warning This routine clobbers XMTRX.
+*/
+SHZ_INLINE void shz_mat4x4_apply_frustum(shz_mat4x4_t* m, float left, float right, float bottom, float top, float znear, float zfar) SHZ_NOEXCEPT;
+
 /*! Multiplies and accumulates the perspective matrix constructed from the given values onto the given matrix.
 
     \warning This routine clobbers XMTRX.

--- a/include/sh4zam/shz_matrix.h
+++ b/include/sh4zam/shz_matrix.h
@@ -477,7 +477,7 @@ SHZ_INLINE void shz_mat4x4_apply_frustum(shz_mat4x4_t* m, float left, float righ
 
     \warning This routine clobbers XMTRX.
 */
-SHZ_INLINE void shz_mat4x4_apply_perspective(shz_mat4x4_t* m, float fov, float aspect, float near_z) SHZ_NOEXCEPT;
+SHZ_INLINE void shz_mat4x4_apply_perspective(shz_mat4x4_t* m, float fov, float aspect, float znear) SHZ_NOEXCEPT;
 
 /*! Multiplies and accumulates the viewport matrix created with the given components ont othe given matrix.
 

--- a/include/sh4zam/shz_matrix.hpp
+++ b/include/sh4zam/shz_matrix.hpp
@@ -317,6 +317,14 @@ namespace shz {
             shz_mat4x4_apply_lookat(this, pos, target, up);
         }
 
+        SHZ_FORCE_INLINE void apply_ortho(float left, float right, float bottom, float top, float znear, float zfar) noexcept {
+            shz_mat4x4_apply_ortho(this, left, right, bottom, top, znear, zfar);
+        }
+
+        SHZ_FORCE_INLINE void apply_frustum(float left, float right, float bottom, float top, float znear, float zfar) noexcept {
+            shz_mat4x4_apply_frustum(this, left, right, bottom, top, znear, zfar);
+        }
+
         SHZ_FORCE_INLINE void apply_perspective(float fov, float aspect, float znear) noexcept {
             shz_mat4x4_apply_perspective(this, fov, aspect, znear);
         }


### PR DESCRIPTION
* Adds `apply_ortho` and `apply_frustum` to C++ interface for matrix.
* Small uneventful typo from change to `near_z` to `znear`.