### PR TITLE
Take constructor by const-ref for ctypes in C++

### DIFF
--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -51,7 +51,7 @@ struct vecN: C {
     vecN() = default;
 
     //! Converting constructor from existing C instance.
-    SHZ_FORCE_INLINE vecN(CType other) noexcept:
+    SHZ_FORCE_INLINE vecN(const CType& other) noexcept:
         CType(other) {}
 
     //! Conversion operator for going from a layout-compatible vector type to a SH4ZAM vector type.
@@ -451,7 +451,7 @@ struct vec3: vecN<vec3, shz_vec3_t, 3> {
     vec3() = default;
 
     //! C constructor: constructs a C++ vec3 from a C shz_vec3_t.
-    SHZ_FORCE_INLINE vec3(shz_vec3_t other) noexcept:
+    SHZ_FORCE_INLINE vec3(const shz_vec3_t& other) noexcept:
         vecN(other) {}
 
     //! Single-value constructor: initializes all components to \p v.
@@ -552,7 +552,7 @@ struct vec4: vecN<vec4, shz_vec4_t, 4> {
     vec4() = default;
 
     //! C Constructor: initializes a C++ shz::vec4 from a C shz_vec4_t.
-    SHZ_FORCE_INLINE vec4(shz_vec4_t other) noexcept:
+    SHZ_FORCE_INLINE vec4(const shz_vec4_t& other) noexcept:
         vecN(other) {}
 
     //! Single-value constructor: initializes each element to the given value.


### PR DESCRIPTION
Fixes substitution failure for this situation:

```
shz::vec2 a{};
const shz::vec2 b{};

shz::vec2 c = a - b;
```

Implicit copy constructor is called on the operator overloads. They might also want to be const-ref but  this should solve the root of it.

> error: call of overloaded ‘vecN(const shz::vec2&)’ is ambiguous

Tries:
> shz::vecN<CRTP, C, R>::vecN(CType)
> shz::vecN<shz::vec2, shz_vec2, 2>::vecN(const shz::vecN<shz::vec2, shz_vec2, 2>&)