### PR TITLE
Add normalized which returns the vector instead of assigning it.

### DIFF
--- a/include/sh4zam/shz_vector.hpp
+++ b/include/sh4zam/shz_vector.hpp
@@ -286,19 +286,29 @@ struct vecN: C {
         return shz_vec_normalize(*static_cast<const CppType*>(this));
     }
 
-    //! Normalizes the given vector.
-    SHZ_FORCE_INLINE void normalize() noexcept {
-        *static_cast<CppType*>(this) = shz_vec_normalize(*static_cast<const CppType*>(this));
-    }
-
     //! Returns the direction vector of a given vector, safely protecting against division-by-zero.
     SHZ_FORCE_INLINE CppType direction_safe() const noexcept {
         return shz_vec_normalize_safe(*static_cast<const CppType*>(this));
     }
 
+    //! Normalizes the given vector.
+    SHZ_FORCE_INLINE void normalize() noexcept {
+        *static_cast<CppType*>(this) = shz_vec_normalize(*static_cast<const CppType*>(this));
+    }
+
     //! Normalizes the given vector, safely protecting against division-by-zero.
     SHZ_FORCE_INLINE void normalize_safe() noexcept {
         *static_cast<CppType*>(this) = shz_vec_normalize_safe(*static_cast<const CppType*>(this));
+    }
+
+    //! Return the normalized vector.
+    SHZ_FORCE_INLINE CppType normalized() noexcept {
+        return shz_vec_normalize(*static_cast<const CppType*>(this));
+    }
+
+    //! Return the normalized vector, safely protecting against division-by-zero.
+    SHZ_FORCE_INLINE CppType normalized_safe() noexcept {
+        return shz_vec_normalize_safe(*static_cast<const CppType*>(this));
     }
 
     //! Returns the magnitude of the difference between two vectors as their distance.


### PR DESCRIPTION
Adds `normalized()` and safe variant so can do something like:

> auto v = (pos - origin).normalized();

Matched format that quaternion uses.