### PR TITLE
QoL overloads for matrix and xmtrx

### DIFF
--- a/include/sh4zam/shz_matrix.hpp
+++ b/include/sh4zam/shz_matrix.hpp
@@ -110,8 +110,16 @@ namespace shz {
             shz_mat4x4_init_translation(this, x, y, z);
         }
 
+        SHZ_FORCE_INLINE void init_translation(vec3 v) noexcept {
+            init_translation(v.x, v.y, v.z);
+        }
+
         SHZ_FORCE_INLINE void init_scale(float x, float y, float z) noexcept {
             shz_mat4x4_init_scale(this, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void init_scale(vec3 v) noexcept {
+            init_scale(v.x, v.y, v.z);
         }
 
         SHZ_FORCE_INLINE void init_rotation_x(float angle) noexcept {
@@ -142,9 +150,12 @@ namespace shz {
             shz_mat4x4_init_rotation_yxz(this, yAngle, xAngle, zAngle);
         }
 
-        //! C++ wrapper for shz_mat4x4_init_rotation().
         SHZ_FORCE_INLINE void init_rotation(float angle, float x, float y, float z) noexcept {
             shz_mat4x4_init_rotation(this, angle, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void init_rotation(float angle, vec3 axis) noexcept {
+            init_rotation(angle, axis.x, axis.y, axis.z);
         }
 
         SHZ_FORCE_INLINE void init_rotation(quat q) noexcept {
@@ -153,6 +164,10 @@ namespace shz {
 
         SHZ_FORCE_INLINE void init_diagonal(float x, float y, float z, float w) noexcept {
             shz_mat4x4_init_diagonal(this, x, y, z, w);
+        }
+
+        SHZ_FORCE_INLINE void init_diagonal(vec4 v) noexcept {
+            init_diagonal(v.x, v.y, v.z, v.w);
         }
 
         SHZ_FORCE_INLINE void init_upper_triangular(float col1, vec2 col2, vec3 col3, vec4 col4) noexcept{
@@ -285,9 +300,17 @@ namespace shz {
         SHZ_FORCE_INLINE void apply_scale(float x, float y, float z) noexcept {
             shz_mat4x4_apply_scale(this, x, y, z);
         }
+        
+        SHZ_FORCE_INLINE void apply_scale(vec3 v) noexcept {
+            apply_scale(v.x, v.y, v.z);
+        }
 
         SHZ_FORCE_INLINE void apply_translation(float x, float y, float z) noexcept {
             shz_mat4x4_apply_translation(this, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void apply_translation(vec3 v) noexcept {
+            apply_translation(v.x, v.y, v.z);
         }
 
         SHZ_FORCE_INLINE void apply_rotation_x(float angle) noexcept {
@@ -320,6 +343,10 @@ namespace shz {
 
         SHZ_FORCE_INLINE void apply_rotation(float angle, float x, float y, float z) noexcept {
             shz_mat4x4_apply_rotation(this, angle, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void apply_rotation(float angle, vec3 axis) noexcept {
+            apply_rotation(angle, axis.x, axis.y, axis.z);
         }
 
         SHZ_FORCE_INLINE void apply_rotation(quat q) noexcept {
@@ -373,8 +400,16 @@ namespace shz {
             shz_mat4x4_translate(this, x, y, z);
         }
 
+        SHZ_FORCE_INLINE void translate(vec3 v) noexcept {
+            translate(v.x, v.y, v.z);
+        }
+
         SHZ_FORCE_INLINE void scale(float x, float y, float z) noexcept {
             shz_mat4x4_scale(this, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void scale(vec3 v) noexcept {
+            scale(v.x, v.y, v.z);
         }
 
         SHZ_FORCE_INLINE void rotate_x(float radians) noexcept {
@@ -407,6 +442,10 @@ namespace shz {
 
         SHZ_FORCE_INLINE void rotate(float radians, float xAxis, float yAxis, float zAxis) noexcept {
             shz_mat4x4_rotate(this, radians, xAxis, yAxis, zAxis);
+        }
+
+        SHZ_FORCE_INLINE void rotate(float radians, vec3 axis) noexcept {
+            rotate(radians, axis.x, axis.y, axis.z);
         }
 
         //! @}

--- a/include/sh4zam/shz_matrix.hpp
+++ b/include/sh4zam/shz_matrix.hpp
@@ -182,6 +182,10 @@ namespace shz {
             shz_mat4x4_init_symmetric_skew(this, x, y, z);
         }
 
+        SHZ_FORCE_INLINE void init_symmetric_skew(vec3 v) noexcept {
+            init_symmetric_skew(v.x, v.y, v.z);
+        }
+
         SHZ_FORCE_INLINE void init_outer_product(vec4 v1, vec4 v2) noexcept {
             shz_mat4x4_init_outer_product(this, v1, v2);
         }
@@ -262,8 +266,16 @@ namespace shz {
             shz_mat4x4_set_translation(this, x, y, z);
         }
 
+        SHZ_FORCE_INLINE void set_translation(vec3 v) noexcept {
+            set_translation(v.x, v.y, v.z);
+        }
+
         SHZ_FORCE_INLINE void set_scale(float x, float y, float z) noexcept {
             shz_mat4x4_set_scale(this, x, y, z);
+        }
+
+        SHZ_FORCE_INLINE void set_scale(vec3 v) noexcept {
+            set_scale(v.x, v.y, v.z);
         }
 
         SHZ_FORCE_INLINE void set_rotation(quat rot) noexcept {
@@ -272,6 +284,10 @@ namespace shz {
 
         SHZ_FORCE_INLINE void set_diagonal(float x, float y, float z, float w) noexcept {
             shz_mat4x4_set_diagonal(this, x, y, z, w);
+        }
+
+        SHZ_FORCE_INLINE void set_diagonal(vec4 v) noexcept {
+            set_diagonal(v.x, v.y, v.z, v.w);
         }
 
         //! @}

--- a/include/sh4zam/shz_xmtrx.hpp
+++ b/include/sh4zam/shz_xmtrx.hpp
@@ -735,6 +735,11 @@ struct xmtrx {
         shz_xmtrx_set_translation(x, y, z);
     }
 
+    //! C++ wrapper around shz_xmtrx_set_translation().
+    SHZ_FORCE_INLINE void set_translation(vec3 v) noexcept {
+        set_translation(v.x, v.y, v.z);
+    }
+
 //! @}
 
 /*! \name  Getters
@@ -769,9 +774,19 @@ struct xmtrx {
         shz_xmtrx_add_diagonal(x, y, z, w);
     }
 
+    //! C++ wrapper around shz_xmtrx_add_diagonal().
+    SHZ_FORCE_INLINE static void add_diagonal(vec4 v) noexcept {
+        add_diagonal(v.x, v.y, v.z, v.w);
+    }
+
     //! C++ wrapper around shz_xmtrx_add_symmetric_skew().
     SHZ_FORCE_INLINE static void add_symmetric_skew(float x, float y, float z) noexcept {
         shz_xmtrx_add_symmetric_skew(x, y, z);
+    }
+    
+    //! C++ wrapper around shz_xmtrx_add_symmetric_skew().
+    SHZ_FORCE_INLINE static void add_symmetric_skew(vec3 v) noexcept {
+        add_symmetric_skew(v.x, v.y, v.z);
     }
 
     //! C++ wrapper around shz_xmtrx_transpose().

--- a/include/sh4zam/shz_xmtrx.hpp
+++ b/include/sh4zam/shz_xmtrx.hpp
@@ -245,9 +245,19 @@ struct xmtrx {
         shz_xmtrx_init_translation(x, y, z);
     }
 
+    //! C++ wrapper around shz_xmtrx_init_translation().
+    SHZ_FORCE_INLINE static void init_translation(vec3 v) noexcept {
+        init_translation(v.x, v.y, v.z);
+    }
+
     //! C++ wrapper around shz_xmtrx_init_scale().
     SHZ_FORCE_INLINE static void init_scale(float x, float y, float z) noexcept {
         shz_xmtrx_init_scale(x, y, z);
+    }
+
+    //! C++ wrapper around shz_xmtrx_init_scale().
+    SHZ_FORCE_INLINE static void init_scale(vec3 v) noexcept {
+        init_scale(v.x, v.y, v.z);
     }
 
     //! C++ wrapper around shz_xmtrx_init_rotation_x().
@@ -290,9 +300,19 @@ struct xmtrx {
         shz_xmtrx_init_rotation(angle, x, y, z);
     }
 
+    //! C++ wrapper around shz_xmtrx_init_rotation().
+    SHZ_FORCE_INLINE static void init_rotation(float angle, vec3 axis) noexcept {
+        init_rotation(angle, axis.x, axis.y, axis.z);
+    }
+
     //! C++ wrapper around shz_xmtrx_init_diagonal().
     SHZ_FORCE_INLINE static void init_diagonal(float x, float y, float z, float w) noexcept {
         shz_xmtrx_init_diagonal(x, y, z, w);
+    }
+
+    //! C++ wrapper around shz_xmtrx_init_diagonal().
+    SHZ_FORCE_INLINE static void init_diagonal(vec4 v) noexcept {
+        init_diagonal(v.x, v.y, v.z, v.w);
     }
 
     //! C++ wrapper around shz_xmtrx_init_upper_triangular().
@@ -437,9 +457,19 @@ struct xmtrx {
         shz_xmtrx_apply_translation(x, y, z);
     }
 
+    //! C++ wrapper around shz_xmtrx_apply_translation().
+    SHZ_FORCE_INLINE static void apply_translation(vec3 v) noexcept {
+        apply_translation(v.x, v.y, v.z);
+    }
+
     //! C++ wrapper around shz_xmtrx_apply_scale().
     SHZ_FORCE_INLINE static void apply_scale(float x, float y, float z) noexcept {
         shz_xmtrx_apply_scale(x, y, z);
+    }
+
+    //! C++ wrapper around shz_xmtrx_apply_scale().
+    SHZ_FORCE_INLINE static void apply_scale(vec3 v) noexcept {
+        apply_scale(v.x, v.y, v.z);
     }
 
     //! C++ wrapper around shz_xmtrx_apply_rotation_x().
@@ -477,9 +507,14 @@ struct xmtrx {
         shz_xmtrx_apply_rotation_yxz(y, x, z);
     }
 
-        // C++ wrapper around shz_xmtrx_apply_rotation().
+    // C++ wrapper around shz_xmtrx_apply_rotation().
     SHZ_FORCE_INLINE static void apply_rotation(float angle, float x, float y, float z) noexcept {
         shz_xmtrx_apply_rotation(angle, x, y, z);
+    }
+
+    // C++ wrapper around shz_xmtrx_apply_rotation().
+        SHZ_FORCE_INLINE static void apply_rotation(float angle, vec3 axis) noexcept {
+        apply_rotation(angle, axis.x, axis.y, axis.z);
     }
 
     //! C++ wrapper around shz_xmtrx_apply_rotation_quat().
@@ -549,9 +584,19 @@ struct xmtrx {
         shz_xmtrx_translate(x, y, z);
     }
 
+    //! C++ wrapper around shz_xmtrx_translate().
+    SHZ_FORCE_INLINE static void translate(vec3 v) noexcept {
+        translate(v.x, v.y, v.z);
+    }
+
     //! C++ wrapper around shz_xmtrx_scale().
     SHZ_FORCE_INLINE static void scale(float x, float y, float z) noexcept {
         shz_xmtrx_scale(x, y, z);
+    }
+
+    //! C++ wrapper around shz_xmtrx_scale().
+    SHZ_FORCE_INLINE static void scale(vec3 v) noexcept {
+        scale(v.x, v.y, v.z);
     }
 
     //! C++ wrapper around shz_xmtrx_rotate_x().
@@ -592,6 +637,11 @@ struct xmtrx {
     //! C++ wrapper around shz_xmtrx_rotate().
     SHZ_FORCE_INLINE static void rotate(float radians, float x, float y, float z) noexcept {
         shz_xmtrx_rotate(radians, x, y, z);
+    }
+
+    //! C++ wrapper around shz_xmtrx_rotate().
+    SHZ_FORCE_INLINE static void rotate(float radians, vec3 axis) noexcept {
+        rotate(radians, axis.x, axis.y, axis.z);
     }
 
 //! @}


### PR DESCRIPTION
Saw the comment by eliasdaler about it. 

Adds overloads that take a vector and just directly passes the components over to the original function. Looks to inline just fine.