### PR TITLE
Zero fr11 unconditionally.

### DIFF
--- a/include/sh4zam/inline/sh4/shz_xmtrx_sh4.inl.h
+++ b/include/sh4zam/inline/sh4/shz_xmtrx_sh4.inl.h
@@ -2055,7 +2055,7 @@ SHZ_INLINE void shz_xmtrx_apply_rotation_x_sh4(float x) SHZ_NOEXCEPT {
         fmov    fr4, fr9
         fmov    fr5, fr10
         fneg    fr9
-        fmul    fr8, fr11
+        fldi0   fr11
         fmov    fr4, fr6
         fldi0   fr4
 


### PR DESCRIPTION
 I'm 90% sure this is my reest with Diddy Kong Racing, and it seems to fix it for me granted, not fully tested.
apply_rotation_x  zeroes fr11 by multiplying it by zero, but fr11 was never set — so if the last float op left an Inf in there, 0 * Inf = NaN, and ftrv shits that NaN across the matrix and I get a blue screen. rotation_y already does it the way I'm changing it to, so I don't know if the fmul is an unsafe optimisation or just a mistake.

Lemme know if you want a repro. can prob get gemini to shit one out. 
or just use the vmu branch of diddy.
